### PR TITLE
[Feature] Authorization mixin for storage of request-header credentials

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -224,10 +224,8 @@ export default Ember.Object.extend(Ember.Evented, {
   /**
     Adds params and headers or Fetch request.
 
-    For example a header is set for Content-Type: application/vnd.api+json
-
-    If an `AuthorizationHeader` key exists in localStorage it will be used for
-    the `Authorization` header value.
+    - The HTTP Header is set for Content-Type: application/vnd.api+json
+    - Sets Authorization header if accessible in the `authorizationCredential` property
 
     @method fetchOptions
     @param {Object} options
@@ -236,16 +234,48 @@ export default Ember.Object.extend(Ember.Evented, {
   fetchOptions(options) {
     let isUpdate;
     options.headers = options.headers || { 'Content-Type': 'application/vnd.api+json' };
-    const authHeader = window.localStorage.getItem('AuthorizationHeader');
-    if (authHeader) {
-      options.headers['Authorization'] = authHeader;
-    }
+    this.fetchAuthorizationHeader(options);
     if (typeof options.update === 'boolean') {
       isUpdate = options.update;
       delete options.update;
     }
     return isUpdate;
   },
+
+  /**
+    Sets Authorization header if accessible in the `authorizationCredential` property
+
+    @method fetchAuthorizationHeader
+    @param {Object} options
+  */
+  fetchAuthorizationHeader(options) {
+    if (options.headers[this.authorizationHeaderField]) {
+      return;
+    } else {
+      const credential = this.get('authorizationCredential');
+      if (credential && this.authorizationHeaderField) {
+        options.headers[this.authorizationHeaderField] = credential;
+      }
+    }
+  },
+
+  /**
+    Authentication credentials/token used with HTTP authentication
+    This property should be added by an Authorization Mixin
+
+    @property authorizationCredential
+    @type String
+  */
+  authorizationCredential: null,
+
+  /**
+    The name of the Authorization request-header field
+    This property should be added by an Authorization Mixin
+
+    @property authorizationHeaderField
+    @type String
+  */
+  authorizationHeaderField: null,
 
   /**
     Hook to customize the URL, e.g. if your API is behind a proxy and you need

--- a/addon/mixins/authorization.js
+++ b/addon/mixins/authorization.js
@@ -1,0 +1,64 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule authorization
+**/
+
+import Ember from 'ember';
+
+/**
+  A Mixin class for storage of credential/token uses with a HTTP Authorization request-header
+
+  The default solution is to use localStorage['AuthorizationHeader'] for the credential
+
+  @class AuthorizationMixin
+*/
+
+export default Ember.Mixin.create({
+
+  /**
+    The name of the Authorization request-header field
+
+    @property authorizationHeaderField
+    @type String
+    @required
+  */
+  authorizationHeaderField: 'Authorization',
+
+  /**
+    The name key, stored locally, that references the Authorization request-header credential/token
+
+    @property authorizationHeaderStorageKey
+    @type String
+    @required
+  */
+  authorizationHeaderStorageKey: 'AuthorizationHeader',
+
+  /**
+    Authentication credentials/token used with HTTP authentication
+
+    @property authorizationCredential
+    @type String
+    @required
+  */
+  authorizationCredential: Ember.computed({
+    get(key) {
+      key = this.get('authorizationHeaderStorageKey');
+      return window[this._storage].getItem(key);
+    },
+    set(key, value) {
+      key = this.get('authorizationHeaderStorageKey');
+      window[this._storage].setItem(key, value);
+      return value;
+    }
+  }),
+
+  /**
+    Storage type localStorage or sessionStorage
+
+    @property _storage
+    @type String
+    @private
+  */
+  _storage: ['localStorage', 'sessionStorage'][0]
+
+});

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,1 +1,10 @@
-export { default } from 'ember-jsonapi-resources/adapters/application';
+import AuthorizationMixin from 'ember-jsonapi-resources/mixins/authorization';
+import ApplicationAdapter from 'ember-jsonapi-resources/adapters/application';
+
+/**
+  Adapter for a JSON API endpoint, combines the addon ApplicationAdapter and AuthorizationMixin
+
+  @class ApplicationAdapter
+  @uses AuthorizationMixin
+*/
+export default ApplicationAdapter.extend(AuthorizationMixin);

--- a/app/mixins/authorization.js
+++ b/app/mixins/authorization.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-jsonapi-resources/mixins/authorization';

--- a/tests/unit/mixins/authorization-test.js
+++ b/tests/unit/mixins/authorization-test.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import AuthorizationMixin from '../../../mixins/authorization';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | authorization', {
+  beforeEach() {
+    window.localStorage.removeItem('AuthorizationHeader');
+  },
+  afterEach() {
+    window.localStorage.removeItem('AuthorizationHeader');
+  }
+});
+
+test('it uses "Authorization" for a header field', function(assert) {
+  let AuthorizationObject = Ember.Object.extend(AuthorizationMixin);
+  let subject = AuthorizationObject.create();
+  let msg = 'Authorization is the value of the property: authorizationHeaderField';
+  assert.equal(subject.get('authorizationHeaderField'), 'Authorization', msg);
+});
+
+test('it uses "AuthorizationHeader" for the storage key used to lookup credentials', function(assert) {
+  let AuthorizationObject = Ember.Object.extend(AuthorizationMixin);
+  let subject = AuthorizationObject.create();
+  let msg = 'AuthorizationHeader is the value of the property: authorizationHeaderStorageKey';
+  assert.equal(subject.get('authorizationHeaderStorageKey'), 'AuthorizationHeader', msg);
+});
+
+test('it has a (private) property _storage set to: "localStorage"', function(assert) {
+  let AuthorizationObject = Ember.Object.extend(AuthorizationMixin);
+  let subject = AuthorizationObject.create();
+  let msg = 'localStorage is the value of the property: _storage';
+  assert.equal(subject.get('_storage'), 'localStorage', msg);
+});
+
+test('it has a property authorizationCredential that gets and sets a credential/token', function(assert) {
+  let AuthorizationObject = Ember.Object.extend(AuthorizationMixin);
+  let subject = AuthorizationObject.create();
+  assert.ok(!subject.get('authorizationCredential'), 'authorizationCredential is not defined yet.');
+
+  let credential = 'supersecrettokenthatnobodycancrack';
+  subject.set('authorizationCredential', credential);
+
+  let msg = 'localStorage["AuthorizationHeader"] is set to ' + credential;
+  assert.equal(window.localStorage.getItem('AuthorizationHeader'), credential, msg);
+
+  msg = 'authorizationCredential is set to ' + credential;
+  assert.equal(subject.get('authorizationCredential'), credential, msg);
+});


### PR DESCRIPTION
Adds a Mixin class for storage of credential/token for storage of a HTTP Authorization request-header credential.

The default solution is to use `localStorage['AuthorizationHeader']` (for the credential) to set the HTTP 'Authorization' request-header (which is assigned by the ApplicationAdapter#fetchOptions method after a call to ApplicationAdapter#fetch).

Adds a new method to the adapter `fetchAuthorizationHeader` which assigns the request-header using properties provided by the AuthorizationMixin `authorizationCredential` and `authorizationHeaderField`. 

The default value of the `authorizationHeaderField` property is `'AuthorizationHeader'`. The default behavior of the computed property `authorizationCredential` is to get/set `localStorage['AuthorizationHeader']`.

The mixin is combined with the adapter in the application adapter to provide the option to add an "Authorization" header with a "credential/token" value (which is used by `window.fetch`, in the adapter).

The example below should work for using ember-simple-auth…

```js
import AuthorizationMixin from 'ember-jsonapi-resources/mixins/authorization';

AuthorizationMixin.reopen({
  authorizationHeaderStorageKey: 'ember_simple_auth:session',
  authorizationCredential: Ember.computed({
    get(key) {
      key = this.get('authorizationHeaderStorageKey');
      const simpleAuthSession = JSON.parse(window.localStorage.getItem(key));
      return 'Bearer ' + simpleAuthSession.secure.access_token;
    }
});
```

[Fixes #22]