### PR TITLE
Add top-level data member to PATCH relationship

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -152,6 +152,7 @@ export default Ember.Object.extend(Ember.Evented, {
     let url = resource.get(['relationships', relationship, 'links', 'self'].join('.'));
     url = url || [this.get('url'), resource.get('id'), 'relationships', relationship].join('/');
     let data = resource.get(['relationships', relationship, 'data'].join('.'));
+    data = { data: data };
     return this.fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(data)

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -147,7 +147,7 @@ test('#updateResource returns null when serializer returns null (nothing changed
   assert.ok(!adapter.fetch.calledOnce, '#fetch method NOT called');
 });
 
-test('#patchRelationship', function(assert) {
+test('#patchRelationship (to-many)', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
   let resource = this.container.lookupFactory('model:posts').create(postMock.data);
@@ -155,7 +155,20 @@ test('#patchRelationship', function(assert) {
   let promise = adapter.patchRelationship(resource, 'comments');
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   let relationURL = 'http://api.pixelhandler.com/api/v1/posts/1/relationships/comments';
-  let jsonBody = '[{"type":"comments","id":"1"}]';
+  let jsonBody = '{"data":[{"type":"comments","id":"1"}]}';
+  let msg = '#fetch called with url and options with data';
+  assert.ok(adapter.fetch.calledWith(relationURL, { method: 'PATCH', body: jsonBody }), msg);
+});
+
+test('#patchRelationship (to-one)', function(assert) {
+  const adapter = this.subject({type: 'posts', url: '/posts'});
+  sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
+  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  resource.addRelationship('author', '1');
+  let promise = adapter.patchRelationship(resource, 'author');
+  assert.ok(typeof promise.then === 'function', 'returns a thenable');
+  let relationURL = 'http://api.pixelhandler.com/api/v1/posts/1/relationships/author';
+  let jsonBody = '{"data":{"type":"authors","id":"1"}}';
   let msg = '#fetch called with url and options with data';
   assert.ok(adapter.fetch.calledWith(relationURL, { method: 'PATCH', body: jsonBody }), msg);
 });


### PR DESCRIPTION
According to JSON API v1.0 the PATCH request to update a relationship must include a top-level member named data containing a resource identifier object or null.