### PR TITLE
added type parameter to the relations

### DIFF
--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -483,7 +483,7 @@ export function hasOne(relation, type) {
   assertDasherizedHasOneRelation(relation);
   const util = RelatedProxyUtil.create({'relationship': relation});
   const path = linksPath(relation);
-  type = (type ? type : relation)
+  type = (type ? type : relation);
   return Ember.computed(path, function () {
     return util.createProxy(this, type, Ember.ObjectProxy);
   }).meta({relation: relation, type: type, kind: 'hasOne'});
@@ -512,7 +512,7 @@ export function hasMany(relation, type) {
   assertDasherizedHasManyRelation(relation);
   const util = RelatedProxyUtil.create({'relationship': relation});
   const path = linksPath(relation);
-  type = (type ? type : relation)
+  type = (type ? type : relation);
   return Ember.computed(path, function () {
     return util.createProxy(this, type, Ember.ArrayProxy);
   }).meta({relation: relation, type: type, kind: 'hasMany'});

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -476,17 +476,20 @@ function linksPath(relation) {
   type is optional and defaults to relation
 
   @method hasOne
-  @param {String} relation
-  @param {String} type
+  @param {Object|String} relation
 */
-export function hasOne(relation, type) {
-  assertDasherizedHasOneRelation(relation);
-  const util = RelatedProxyUtil.create({'relationship': relation});
-  const path = linksPath(relation);
-  type = (type ? type : relation);
+export function hasOne(relation) {
+  let relationName = relation;
+  if (typeof relation !== 'string') {
+    relationName = relation.resource;
+  }
+  const util = RelatedProxyUtil.create({'relationship': relationName});
+  const path = linksPath(relationName);
+  assertDasherizedHasOneRelation(relationName);
+  const type = (relation.type ? relation.type : relationName);
   return Ember.computed(path, function () {
     return util.createProxy(this, type, Ember.ObjectProxy);
-  }).meta({relation: relation, type: type, kind: 'hasOne'});
+  }).meta({relation: relationName, type: type, kind: 'hasOne'});
 }
 
 function assertDasherizedHasOneRelation(name) {
@@ -505,17 +508,20 @@ function assertDasherizedHasOneRelation(name) {
   type is optional and defaults to relation
 
   @method hasMany
-  @param {String} relation
-  @param {String} type
+  @param {String|Object} relation
 */
-export function hasMany(relation, type) {
-  assertDasherizedHasManyRelation(relation);
-  const util = RelatedProxyUtil.create({'relationship': relation});
-  const path = linksPath(relation);
-  type = (type ? type : relation);
+export function hasMany(relation) {
+  let relationName = relation;
+  if (typeof relation !== 'string') {
+    relationName = relation.resource;
+  }
+  const util = RelatedProxyUtil.create({'relationship': relationName});
+  const path = linksPath(relationName);
+  assertDasherizedHasManyRelation(relationName);
+  const type = (relation.type ? relation.type : relationName);
   return Ember.computed(path, function () {
     return util.createProxy(this, type, Ember.ArrayProxy);
-  }).meta({relation: relation, type: type, kind: 'hasMany'});
+  }).meta({relation: relationName, type: type, kind: 'hasMany'});
 }
 
 function assertDasherizedHasManyRelation(name) {

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -388,12 +388,12 @@ const RelatedProxyUtil = Ember.Object.extend({
     @param {Ember.ObjectProxy|Ember.ArrayProxy} proxyFactory
     @return {PromiseProxy} proxy
   */
-  createProxy: function (resource, proxyFactory) {
+  createProxy: function (resource, type, proxyFactory) {
     const relation = this.get('relationship');
     const url = this.proxyUrl(resource, relation);
-    const service = resource.container.lookup('service:' + pluralize(relation));
+    const service = resource.container.lookup('service:' + pluralize(type));
     let promise = this.promiseFromCache(resource, relation, service);
-    promise = promise || service.findRelated(relation, url);
+    promise = promise || service.findRelated(type, url);
     let proxy = proxyFactory.extend(Ember.PromiseProxyMixin, {
       'promise': promise, 'type': relation
     });
@@ -472,18 +472,21 @@ function linksPath(relation) {
 }
 
 /**
-  Helper to setup a has one relationship to another resource
+  Helper to setup a has one relationship to another resource,
+  type is optional and defaults to relation
 
   @method hasOne
   @param {String} relation
+  @param {String} type
 */
-export function hasOne(relation) {
+export function hasOne(relation, type) {
   assertDasherizedHasOneRelation(relation);
   const util = RelatedProxyUtil.create({'relationship': relation});
   const path = linksPath(relation);
+  type = (type ? type : relation)
   return Ember.computed(path, function () {
-    return util.createProxy(this, Ember.ObjectProxy);
-  }).meta({relation: relation, kind: 'hasOne'});
+    return util.createProxy(this, type, Ember.ObjectProxy);
+  }).meta({relation: relation, type: type, kind: 'hasOne'});
 }
 
 function assertDasherizedHasOneRelation(name) {
@@ -498,18 +501,21 @@ function assertDasherizedHasOneRelation(name) {
 }
 
 /**
-  Helper to setup a has many relationship to another resource
+  Helper to setup a has many relationship to another resource,
+  type is optional and defaults to relation
 
   @method hasMany
   @param {String} relation
+  @param {String} type
 */
-export function hasMany(relation) {
+export function hasMany(relation, type) {
   assertDasherizedHasManyRelation(relation);
   const util = RelatedProxyUtil.create({'relationship': relation});
   const path = linksPath(relation);
+  type = (type ? type : relation)
   return Ember.computed(path, function () {
-    return util.createProxy(this, Ember.ArrayProxy);
-  }).meta({relation: relation, kind: 'hasMany'});
+    return util.createProxy(this, type, Ember.ArrayProxy);
+  }).meta({relation: relation, type: type, kind: 'hasMany'});
 }
 
 function assertDasherizedHasManyRelation(name) {


### PR DESCRIPTION
The type parameter is necessary to choose the service build the right
resources. The type is not always the same as the relation name.

For instance say there is a Person that has a relationship called 'friends' to other Persons and a relationship called 'children' to other Persons as well. The specification in the resource would now be:

    friends: hasMany('friends', 'persons')
    offspring: hasMany('children', 'persons')

The previously you would get an exception when the name of the relation was not the same as the type. 

The type is now the second argument in the specification of the relation in the resource, but it is optional. If the type is indeed the same as the relation name, it can be omitted.