### PR TITLE
Show error message on fetch error

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -222,7 +222,7 @@ export default Ember.Object.extend(Ember.Evented, {
           });
         }
       }).catch(function(error) {
-        reject(new FetchError('Unable to Fetch resource(s)', error));
+        reject(new FetchError('Unable to Fetch resource(s): ' + error.message, error));
       });
     });
   },


### PR DESCRIPTION
```
Fetch Error: Unable to Fetch resource(s)
```

Becomes

```
Fetch Error: Unable to Fetch resource(s): Pretender intercepted GET /supports but no handler was defined for this type of request
```

(or would this be better in a console warning?)
