### PR TITLE
Add options argument for findOne/findMany Resource helpers

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -92,11 +92,19 @@ export default Ember.Object.extend(Ember.Evented, {
 
     @method findRelated
     @param {String} resource name (plural) to lookup the service object w/ serializer
+      or {Object} `{'resource': relation, 'type': type}` used when type is not the
+      same as the resource name, to fetch relationship using a different service
     @param {String} url
     @return {Promise}
   */
   findRelated(resource, url) {
-    const service = this.container.lookup('service:' + pluralize(resource));
+    let type = resource;
+    if (typeof type === 'object') {
+      resource = resource.resource;
+      type = resource.type;
+    }
+    let service = this.container.lookup('service:' + pluralize(type));
+    url = this.fetchUrl(url);
     return service.fetch(url, { method: 'GET' });
   },
 

--- a/tests/helpers/resources.js
+++ b/tests/helpers/resources.js
@@ -28,6 +28,21 @@ export const Commenter = Resource.extend({
   comments: hasMany('comments')
 });
 
+export const Person = Resource.extend({
+  type: 'people',
+  name: attr()
+});
+
+export const Employee = Person.extend({
+  type: 'employees',
+  supervisor: hasOne({ resource: 'supervisor', type: 'people' })
+});
+
+export const Supervisor = Employee.extend({
+  type: 'supervisors',
+  directReports: hasMany({ resource: 'employees', type: 'people' })
+});
+
 export function setup() {
   const opts = { instantiate: false, singleton: false };
   Post.prototype.container = this.container;
@@ -38,6 +53,12 @@ export function setup() {
   this.registry.register('model:comments', Comment, opts);
   Commenter.prototype.container = this.container;
   this.registry.register('model:commenters', Commenter, opts);
+  Person.prototype.container = this.container;
+  this.registry.register('model:persons', Person, opts);
+  Employee.prototype.container = this.container;
+  this.registry.register('model:employees', Employee, opts);
+  Supervisor.prototype.container = this.container;
+  this.registry.register('model:supervisors', Supervisor, opts);
 }
 
 export function teardown() {


### PR DESCRIPTION
- Relationship helpers may use a String argument for the relation name,
  as found in the relationship object of the JSON payload
- Helpers may instead use an Object argument with properties for relation
  and type (type is different service) to use for fetching resource relations

[Fixes #36]