### PR TITLE
attr() helper may use optional type

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ work together to provide a basic plan.
 The services are "evented" to facilitate close to real time updates.
 
 An `attr` of the resource is a computed property to the actual attribute in an 
-`attributes` hash on the `resource` (model) instance.
+`attributes` hash on the `resource` (model) instance. Using `attr()` supports
+any type, and an optional `type` (String) argument can be used to enforce
+setting and getting with a specific type. `'string'`, `'number'`, `'boolean'`,
+`'date'`, `'object'`, and `'array'` are all valid types for attributes.
 
 When an `attr` is `set` and the value has changed an `attributeChanged` event
 is triggered on the `resource`'s service object. By default, the adapter listens
@@ -264,8 +267,13 @@ export default Resource.extend({
   service: Ember.inject.service('<%= resource %>'),
 
   /*
-  title: attr(),
-  date: attr(),
+  title: attr('string'),
+  published: attr('date'),
+  tags: attr('array'),
+  footnotes: attr('object'),
+  revisions: attr()
+  version: attr('number'),
+  "is-approved": attr('boolean'),
 
   author: hasOne('author'),
   comments: hasMany('comments')

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -86,14 +86,24 @@ export default Ember.Object.extend(Ember.Evented, {
   },
 
   /**
-    Find resources using an optional query object, e.g. w/ pagination params
+    Find resources by relationship or use a specificed (optional) service to find relation
 
     A Url like: /photos/1/relationships/photographer is a required param
 
+    ```js
+    service.findRelated('photographer', '/api/v1/photos/1/relationships/photographer');
+    ```
+
+    Or, with option to find releated resource using a different service
+
+    ```js
+    service.findRelated({resource: 'photographer', type: 'people'}, url);
+    ```
+
     @method findRelated
-    @param {String} resource name (plural) to lookup the service object w/ serializer
-      or {Object} `{'resource': relation, 'type': type}` used when type is not the
-      same as the resource name, to fetch relationship using a different service
+    @param {String|Object} resource name to lookup the service object w/ serializer
+    @param {String} resource.resource the name of the resource
+    @param {String} resource.type the name of the resource
     @param {String} url
     @return {Promise}
   */

--- a/addon/mixins/service-cache.js
+++ b/addon/mixins/service-cache.js
@@ -145,7 +145,7 @@ export default Ember.Mixin.create({
 
     @method cacheLookup
     @param {String} id
-    @returns {Resource|undefined}
+    @return {Resource|undefined}
   */
   cacheLookup(id) {
     return this.cache.data.find(function(resource) {

--- a/addon/utils/attr.js
+++ b/addon/utils/attr.js
@@ -1,0 +1,115 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import Ember from 'ember';
+import { isBlank, isDasherized, isType } from 'ember-jsonapi-resources/utils/is';
+
+/**
+  Utility helper to setup a computed property for a resource attribute, imported and
+  exported with the resource submodule.
+
+  An `attr` of the resource is a computed property to the actual attribute in an
+  `attributes` hash on the `resource` (model) instance. Using `attr()` supports
+  any type, and an optional `type` (String) argument can be used to enforce
+  setting and getting with a specific type. `'string'`, `'number'`, `'boolean'`,
+  `'date'`, `'object'`, and `'array'` are all valid types for attributes.
+
+  Use `attr()`, with optional type argument, to compose your model attributes, e.g:
+
+  ```js
+  import Ember from 'ember';
+  import Resource from 'ember-jsonapi-resources/models/resource';
+  import { attr, hasOne, hasMany } from 'ember-jsonapi-resources/models/resource';
+
+  export default Resource.extend({
+    type: 'articles',
+    service: Ember.inject.service('articles'),
+
+    title: attr('string'),
+    published: attr('date'),
+    tags: attr('array'),
+    footnotes: attr('object'),
+    revisions: attr()
+    version: attr('number'),
+    "is-approved": attr('boolean')
+  });
+  ```
+
+  @method attr
+  @param {String} [type] an optional param for the type of property, i.e. `string`,
+    `number`, `boolean`, `date`, `object`, or `array`
+  @param {Boolean} [mutable=true] optional param, defaults to `true` if not passed
+*/
+export default function attr(type = 'any', mutable = true) {
+  const _mutable = mutable;
+  if (type !== 'any' && !isBlank(type)) {
+    assertValidTypeOption(type);
+  }
+  return Ember.computed('attributes', {
+    get: function (key) {
+      assertDasherizedAttr(key);
+      let value = this.get('attributes.' + key);
+      if (!isBlank(value)) {
+        assertType.call(this, key, value);
+      }
+      return value;
+    },
+
+    set: function (key, value) {
+      const lastValue = this.get('attributes.' + key);
+      if (!_mutable) {
+        return immutableValue(key, value, lastValue);
+      }
+      if (value === lastValue) { return value; }
+      assertType.call(this, key, value);
+      this.set('attributes.' + key, value);
+      if (!this.get('isNew')) {
+        this._attributes[key] = this._attributes[key] || {};
+        this._attributes[key].changed = value;
+        this._attributes[key].previous = lastValue;
+        const service = this.get('service');
+        if (service) {
+          service.trigger('attributeChanged', this);
+        }
+      }
+      return this.get('attributes.' + key);
+    }
+  }).meta({type: type, mutable: mutable});
+}
+
+function assertValidTypeOption(type) {
+  if (type === 'any') { return; }
+  let allowed = 'string number boolean date object array';
+  let msg = 'Allowed types are: ' + allowed + ' however ' + type + ' was given instead.';
+  Ember.assert(msg, allowed.split(' ').indexOf(type) > -1);
+}
+
+function assertDasherizedAttr(name) {
+  try {
+    let attrName = Ember.String.dasherize(name);
+    let msg = "Attributes are recommended to use dasherized names, e.g `'"+ attrName +"': attr()`";
+    msg += ", instead of `"+ name +": attr()`";
+    Ember.assert(msg, isDasherized(name));
+  } catch(e) {
+    Ember.Logger.warn(e.message);
+  }
+}
+
+function assertType(key, value) {
+  let meta = this.constructor.metaForProperty(key);
+  if (meta && meta.type && meta.type !== 'any') {
+    let msg = this.toString() + '#' + key + ' is expected to be a ' + meta.type;
+    Ember.assert(msg, isType(meta.type, value));
+  }
+}
+
+function immutableValue(key, value, lastValue) {
+  let msg = [
+    this.toString(), '#', key, ' is not mutable set was called with ',
+    '`', value, '`', ' but is previous set to `', lastValue, '`'
+  ];
+  Ember.Logger.warn(msg.join(''));
+  return lastValue;
+}

--- a/addon/utils/has-many.js
+++ b/addon/utils/has-many.js
@@ -1,0 +1,74 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import Ember from 'ember';
+import RelatedProxyUtil from 'ember-jsonapi-resources/utils/related-proxy';
+import { linksPath } from 'ember-jsonapi-resources/utils/related-proxy';
+import { isDasherized } from 'ember-jsonapi-resources/utils/is';
+
+/**
+  Helper to setup a has many relationship to another resource
+
+  ```js
+  let Author = Resource.extend({
+    type: 'authors',
+    name: attr(),
+    posts: hasMany('posts')
+  });
+  ```
+
+  Or, with an optional type to use instead of the resource's service
+
+  ```js
+  let Person = Resource.extend({
+    type: 'people',
+    name: attr()
+  });
+
+  let Supervisor = Person.extend({
+    type: 'supervisors',
+    directReports: hasMany({ resource: 'employees', type: 'people' })
+  });
+  ```
+
+  @method hasMany
+  @param {String|Object} relation the name of the relationship
+  @param {String} relation.resource the name of the relationship
+  @param {String} relation.type the name of the type or service to use
+*/
+export default function hasMany(relation) {
+  let type = relation;
+  if (typeof type === 'object') {
+    assertResourceAndTypeProps(relation);
+    type = relation.type;
+    relation = relation.resource;
+  }
+  assertDasherizedHasManyRelation(relation);
+  let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
+  let path = linksPath(relation);
+  return Ember.computed(path, function () {
+    return util.createProxy(this, Ember.ArrayProxy);
+  }).meta({relation: relation, type: type, kind: 'hasMany'});
+}
+
+function assertResourceAndTypeProps(relation) {
+  try {
+    let msg = 'Options must include properties: resource, type';
+    Ember.assert(msg, relation && relation.resource && relation.type);
+  } catch(e) {
+    Ember.Logger.warn(e.message);
+  }
+}
+
+function assertDasherizedHasManyRelation(name) {
+  try {
+    let relationName = Ember.String.dasherize(name);
+    let msg = " are recommended to use dasherized names, e.g `hasMany('"+ relationName +"')`";
+    msg += ", instead of `hasMany('"+ name +"')`";
+    Ember.assert(msg, isDasherized(name));
+  } catch(e) {
+    Ember.Logger.warn(e.message);
+  }
+}

--- a/addon/utils/has-one.js
+++ b/addon/utils/has-one.js
@@ -1,0 +1,73 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import Ember from 'ember';
+import RelatedProxyUtil from 'ember-jsonapi-resources/utils/related-proxy';
+import { linksPath } from 'ember-jsonapi-resources/utils/related-proxy';
+import { isDasherized } from 'ember-jsonapi-resources/utils/is';
+
+/**
+  Helper to setup a has one relationship to another resource
+
+  ```js
+  let Employee = Person.extend({
+    type: 'employees',
+    supervisor: hasOne('supervisor')
+  });
+  ```
+
+  Or, with an optional type to use instead of the resource's service
+
+  ```js
+  let Person = Resource.extend({
+    type: 'people',
+    name: attr()
+  });
+
+  let Employee = Person.extend({
+    type: 'employees',
+    supervisor: hasOne({ resource: 'supervisor', type: 'people' })
+  });
+  ```
+
+  @method hasOne
+  @param {String|Object} relation the name of the relationship
+  @param {String} relation.resource the name of the relationship
+  @param {String} relation.type the name of the type or service to use
+*/
+export default function hasOne(relation) {
+  let type = relation;
+  if (typeof type === 'object') {
+    assertResourceAndTypeProps(relation);
+    type = relation.type;
+    relation = relation.resource;
+  }
+  assertDasherizedHasOneRelation(type);
+  let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
+  let path = linksPath(relation);
+  return Ember.computed(path, function () {
+    return util.createProxy(this, Ember.ObjectProxy);
+  }).meta({relation: relation, type: type, kind: 'hasOne'});
+}
+
+function assertResourceAndTypeProps(relation) {
+  try {
+    let msg = 'Options must include properties: resource, type';
+    Ember.assert(msg, relation && relation.resource && relation.type);
+  } catch(e) {
+    Ember.Logger.warn(e.message);
+  }
+}
+
+function assertDasherizedHasOneRelation(name) {
+  try {
+    let relationName = Ember.String.dasherize(name);
+    let msg = " are recommended to use dasherized names, e.g `hasOne('"+ relationName +"')`";
+    msg += ", instead of `hasOne('"+ name +"')`";
+    Ember.assert(msg, isDasherized(name));
+  } catch(e) {
+    Ember.Logger.warn(e.message);
+  }
+}

--- a/addon/utils/is.js
+++ b/addon/utils/is.js
@@ -1,0 +1,20 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import Ember from 'ember';
+
+export function isBlank(value) {
+  return value === null || typeof value === 'undefined';
+}
+
+export function isDasherized(name) {
+  return (Ember.String.dasherize(name) === name);
+}
+
+export function isType(type, value) {
+  type = Ember.String.capitalize(type);
+  type = `[object ${type}]`;
+  return Object.prototype.toString.call(value) === type;
+}

--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -1,0 +1,140 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
+
+/**
+  Utility for creating promise proxy objects for related resources
+
+  @class RelatedProxyUtil
+  @static
+*/
+const RelatedProxyUtil = Ember.Object.extend({
+
+  /**
+    Checks for required `relationship` property
+
+    @method init
+  */
+  init: function () {
+    this._super();
+    if (typeof this.get('relationship') !== 'string') {
+      throw new Error('RelatedProxyUtil#init expects `relationship` property to exist.');
+    }
+    return this;
+  },
+
+  /**
+    The name of the relationship
+
+    @property resource
+    @type String
+    @required
+  */
+  relationship: null,
+
+  /**
+    The name of the type of resource
+
+    @property type
+    @type String
+    @required
+  */
+  type: null,
+
+  /**
+    Proxy for the requested relation, resolves w/ content from fulfilled promise
+
+    @method createProxy
+    @param {Resource} resource
+    @param {Ember.ObjectProxy|Ember.ArrayProxy} proxyFactory
+    @return {PromiseProxy} proxy
+  */
+  createProxy: function (resource, proxyFactory) {
+    let relation = this.get('relationship');
+    let type = this.get('type');
+    let url = this.proxyUrl(resource, relation);
+    let service = resource.container.lookup('service:' + pluralize(type));
+    let promise = this.promiseFromCache(resource, relation, service);
+    promise = promise || service.findRelated({'resource': relation, 'type': type}, url);
+    let proxy = proxyFactory.extend(Ember.PromiseProxyMixin, {
+      'promise': promise, 'type': relation
+    });
+    proxy = proxy.create();
+    proxy.then(
+      function (resources) {
+        proxy.set('content', resources);
+      },
+      function (error) {
+        Ember.Logger.error(error);
+        throw error;
+      }
+    );
+    return proxy;
+  },
+
+  /**
+    Proxy url to fetch for the resource's relation
+
+    @method proxyUrl
+    @param {Resource} resource
+    @param {String} relation
+    @return {PromiseProxy} proxy
+  */
+  proxyUrl(resource, relation) {
+    const related = linksPath(relation);
+    const url = resource.get(related);
+    if (typeof url !== 'string') {
+      throw new Error('RelatedProxyUtil#_proxyUrl expects `model.'+ related +'` property to exist.');
+    }
+    return url;
+  },
+
+  /**
+    Lookup relation from service cache and pomisify result
+
+    @method promiseFromCache
+    @param {Resource} resource
+    @param {String} relation
+    @param {Object} service
+    @return {Promise|null}
+  */
+  promiseFromCache(resource, relation, service) {
+    let data = resource.get('relationships.' + relation + '.data');
+    if (!data) { return; }
+    let content = Ember.A([]), found;
+    if (Array.isArray(data)) {
+      for (let i = 0; i < data.length; i++) {
+        found = this.serviceCacheLookup(service, data[i]);
+        if (found) {
+          content.push(found);
+        }
+      }
+      content = (data.length && data.length === content.length) ? content : null;
+    } else {
+      content = this.serviceCacheLookup(service, data);
+    }
+    return (content) ? Ember.RSVP.Promise.resolve(content) : null;
+  },
+
+  /**
+    Lookup data in service cache
+
+    @method serviceCacheLookup
+    @param {Object} service
+    @param {Object} data
+    @return {Resource|undefined}
+  */
+  serviceCacheLookup(service, data) {
+    return (typeof data === 'object' && data.id) ? service.cacheLookup(data.id) : undefined;
+  }
+});
+
+export default RelatedProxyUtil;
+
+export function linksPath(relation) {
+  return ['relationships', relation, 'links', 'related'].join('.');
+}

--- a/blueprints/model/files/__root__/__path__/__name__.js
+++ b/blueprints/model/files/__root__/__path__/__name__.js
@@ -7,8 +7,13 @@ export default Resource.extend({
   service: Ember.inject.service('<%= resource %>'),
 
   /*
-  title: attr(),
-  date: attr(),
+  title: attr('string'),
+  published: attr('date'),
+  tags: attr('array'),
+  footnotes: attr('object'),
+  revisions: attr()
+  version: attr('number'),
+  "is-approved": attr('boolean'),
 
   author: hasOne('author'),
   comments: hasMany('comments')

--- a/tests/unit/utils/attr-test.js
+++ b/tests/unit/utils/attr-test.js
@@ -1,0 +1,296 @@
+import attr from 'ember-jsonapi-resources/utils/attr';
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+let Resource = Ember.Object.extend({ attributes: {}, _attributes: {} });
+
+module('Unit | Utility | attr');
+
+test('attr("string") setting with a string', function(assert) {
+  let Person = Resource.extend({
+    name: attr('string')
+  });
+  let person = Person.create();
+  person.set('name', 'Wyatt Earp');
+  assert.equal(person.get('name'), 'Wyatt Earp', 'person name is set with a string');
+});
+
+test('attr("string") getting a string', function(assert) {
+  let Person = Resource.extend({
+    name: attr('string')
+  });
+  let person = Person.create({ attributes: { name: 'Wyatt Earp'} });
+  assert.equal(person.get('name'), 'Wyatt Earp', 'person.get("name") is a string');
+});
+
+test('using attr("string") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    name: attr('string')
+  });
+  let person = Person.create();
+  assert.throws(function() {
+    person.set('name', false);
+  }, 'Setting name to `false` throws an assertion error');
+});
+
+test('using attr("string") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    name: attr('string')
+  });
+  let person = Person.create({ attributes: { name: false} });
+  assert.throws(function() {
+    person.get('name');
+  }, 'Getting name already set with `false` value throws an assertion error');
+});
+
+test('attr("boolean" setting a boolean)', function(assert) {
+  let Person = Resource.extend({
+    isCowboy: attr('boolean')
+  });
+  let person = Person.create();
+  person.set('isCowboy', true);
+  assert.equal(person.get('isCowboy'), true, 'person set with a boolean attribute');
+});
+
+test('attr("boolean" getting a boolean)', function(assert) {
+  let Person = Resource.extend({
+    isCowboy: attr('boolean')
+  });
+  let person = Person.create({ attributes: {'isCowboy': true} });
+  assert.equal(person.get('isCowboy'), true, 'person.get("isCowboy") is a boolean attribute');
+});
+
+test('using attr("boolean") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    isCowboy: attr('boolean')
+  });
+  let person = Person.create();
+  assert.throws(function() {
+    person.set('isCowboy', 'yep');
+  }, 'Setting isCowboy to `"yep"` throws an assertion error');
+});
+
+test('using attr("boolean") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    isCowboy: attr('boolean')
+  });
+  let person = Person.create({ attributes: {'isCowboy': 'yep'} });
+  assert.throws(function() {
+    person.get('isCowboy');
+  }, 'Getting isCowboy already set with a `"yep"` throws an assertion error');
+});
+
+test('attr("number") setting a number', function(assert) {
+  let Person = Resource.extend({
+    birthYear: attr('number')
+  });
+  let person = Person.create();
+  person.set('birthYear', 1848);
+  assert.equal(person.get('birthYear'), 1848, 'person set with a number attribute');
+});
+
+test('attr("number") getting a number', function(assert) {
+  let Person = Resource.extend({
+    birthYear: attr('number')
+  });
+  let person = Person.create({ attributes: {'birthYear': 1848} });
+  assert.equal(person.get('birthYear'), 1848, 'person.get("birthYear") is a number');
+});
+
+test('using attr("number") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    birthYear: attr('number')
+  });
+  let person = Person.create();
+  assert.throws(function() {
+    person.set('birthYear', '1848');
+  }, 'Setting birthYear to `"1848"` throws an assertion error');
+});
+
+test('using attr("number") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    birthYear: attr('number')
+  });
+  let person = Person.create({ attributes: {'birthYear': '1848'} });
+  assert.throws(function() {
+    person.get('birthYear');
+  }, 'Getting birthYear already set to `"1848"` throws an assertion error');
+});
+
+test('attr("date") setting with a date type', function(assert) {
+  let Person = Resource.extend({
+    birthdate: attr('date')
+  });
+  let person = Person.create();
+  let birthdate = new Date('March 19, 1848');
+  person.set('birthdate', birthdate);
+  assert.equal(person.get('birthdate'), birthdate, 'person set with a date attribute');
+});
+
+test('attr("date") getting a date type', function(assert) {
+  let Person = Resource.extend({
+    birthdate: attr('date')
+  });
+  let birthdate = new Date('March 19, 1848');
+  let person = Person.create({ attributes: {'birthdate': birthdate} });
+  assert.equal(person.get('birthdate'), birthdate, 'person set with a date attribute');
+});
+
+test('using attr("date") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    birthdate: attr('date')
+  });
+  let person = Person.create();
+
+  assert.throws(function() {
+    person.set('birthdate', 'March 19, 1848');
+  }, 'Setting birthdate to `"March 19, 1848"` throws an assertion error');
+});
+
+test('using attr("date") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    birthdate: attr('date')
+  });
+  let person = Person.create({ attributes: {'birthdate': 'March 19, 1848'} });
+
+  assert.throws(function() {
+    person.qet('birthdate');
+  }, 'Getting birthdate already set to `"March 19, 1848"` throws an assertion error');
+});
+
+test('attr("object") setting a object', function(assert) {
+  let Person = Resource.extend({
+    lifespan: attr('object')
+  });
+  let person = Person.create();
+  let lifespan = { birth: 'March 19, 1848', death: 'January 13, 1929', aged: 80 };
+  person.set('lifespan', lifespan);
+  assert.deepEqual(person.get('lifespan'), lifespan, 'person set with a object attribute');
+});
+
+test('attr("object") getting an object', function(assert) {
+  let Person = Resource.extend({
+    lifespan: attr('object')
+  });
+  let lifespan = { birth: 'March 19, 1848', death: 'January 13, 1929', aged: 80 };
+  let person = Person.create({ attributes: {'lifespan': lifespan} });
+  assert.deepEqual(person.get('lifespan'), lifespan, 'person.get("lifespan") is a object attribute');
+});
+
+test('using attr("object") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    lifespan: attr('object')
+  });
+  let person = Person.create();
+  assert.throws(function() {
+    person.set('lifespan', 'aged: 80');
+  }, 'Setting lifespan to `"aged: 80"` throws an assertion error');
+});
+
+test('using attr("object") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    lifespan: attr('object')
+  });
+  let person = Person.create({ attributes: { lifespan: ['March 19, 1848', 'January 13, 1929', 80 ]} });
+  assert.throws(function() {
+    person.get('lifespan');
+  }, 'Getting lifespan already set to an array throws an assertion error');
+});
+
+test('attr("array") setting an array type', function(assert) {
+  let Person = Resource.extend({
+    relatives: attr('array')
+  });
+  let person = Person.create();
+  let relatives = 'Virgil, James, Morgan, Warren'.split(', ');
+  person.set('relatives', relatives);
+  assert.deepEqual(person.get('relatives'), relatives, 'person set with an array attribute');
+});
+
+test('attr("array") getting an array type', function(assert) {
+  let Person = Resource.extend({
+    relatives: attr('array')
+  });
+  let relatives = 'Virgil, James, Morgan, Warren'.split(', ');
+  let person = Person.create({ attributes: {relatives: relatives} });
+  assert.deepEqual(person.get('relatives'), relatives, 'person.get("relatives") is an array');
+});
+
+test('using attr("array") throws an assertion error when setting with another type', function(assert) {
+  let Person = Resource.extend({
+    relatives: attr('array')
+  });
+  let person = Person.create();
+  assert.throws(function() {
+    person.set('relatives', 'Virgil, James, Morgan, Warren');
+  }, 'Setting relatives to `"Virgil, James, Morgan, Warren"` throws an assertion error');
+});
+
+test('using attr("array") throws an assertion error when getting with another type', function(assert) {
+  let Person = Resource.extend({
+    relatives: attr('array')
+  });
+  let relatives = 'Virgil, James, Morgan, Warren';
+  let person = Person.create({ attributes: {relatives: relatives} });
+  assert.throws(function() {
+    person.get('relatives');
+  }, 'Getting relatives when already set to `"' + relatives + '"` throws an assertion error');
+});
+
+test('attr() default is any type, works with a string', function(assert) {
+  let Thing = Resource.extend({
+    misc: attr()
+  });
+  let thing = Thing.create();
+  thing.set('misc', 'string');
+  assert.equal(thing.get('misc'), 'string', 'thing set with a string attribute');
+  thing = Thing.create({ attributes: {misc: 'string'} });
+  assert.equal(thing.get('misc'), 'string', 'thing.get("misc") is a string');
+});
+
+test('attr() default is any type, works with a number', function(assert) {
+  let Thing = Resource.extend({
+    misc: attr()
+  });
+  let thing = Thing.create();
+  thing.set('misc', 101);
+  assert.equal(thing.get('misc'), 101, 'thing set with a number attribute');
+  thing = Thing.create({ attributes: {misc: 101} });
+  assert.equal(thing.get('misc'), 101, 'thing.get("misc") is a number');
+});
+
+test('attr() default is any type, works with a date', function(assert) {
+  let Thing = Resource.extend({
+    misc: attr()
+  });
+  let thing = Thing.create();
+  let date = new Date('March 19, 1848');
+  thing.set('misc', date);
+  assert.equal(thing.get('misc'), date, 'thing set with a date attribute');
+  thing = Thing.create({ attributes: {misc: date} });
+  assert.equal(thing.get('misc'), date, 'thing.get("misc") is a date');
+});
+
+test('attr() default is any type, works with an object', function(assert) {
+  let Thing = Resource.extend({
+    misc: attr()
+  });
+  let thing = Thing.create();
+  let obj = {number: 42};
+  thing.set('misc', obj);
+  assert.deepEqual(thing.get('misc'), obj, 'thing set with an object attribute');
+  thing = Thing.create({ attributes: {misc: obj} });
+  assert.equal(thing.get('misc'), obj, 'thing.get("misc") is an object');
+});
+
+test('attr() default is any type, works with an array', function(assert) {
+  let Thing = Resource.extend({
+    misc: attr()
+  });
+  let thing = Thing.create();
+  let arr = 'Virgil, James, Morgan, Warren'.split(', ');
+  thing.set('misc', arr);
+  assert.deepEqual(thing.get('misc'), arr, 'thing set with a array attribute');
+  thing = Thing.create({ attributes: {misc: arr} });
+  assert.equal(thing.get('misc'), arr, 'thing.get("misc") is an array');
+});

--- a/tests/unit/utils/has-many-test.js
+++ b/tests/unit/utils/has-many-test.js
@@ -1,0 +1,60 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
+import { setup, teardown } from 'dummy/tests/helpers/resources';
+
+let mockServices;
+const mockService = function () {
+  let sandbox = this.sandbox;
+  return Ember.Service.extend({
+    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(null); }),
+    cacheLookup: sandbox.spy(function () { return []; })
+  });
+};
+let entities = ['post', 'author'];
+
+moduleFor('model:resource', 'Unit | Utility | hasMany', {
+  beforeEach() {
+    setup.call(this);
+    this.sandbox = window.sinon.sandbox.create();
+    mockServices = {};
+    entities.forEach(function (entity) {
+      let serviceName = pluralize(entity);
+      mockServices[serviceName] = mockService.call(this);
+      this.registry.register('service:'+serviceName, mockServices[serviceName]);
+    }.bind(this));
+  },
+  afterEach() {
+    mockServices = null;
+    teardown();
+    this.sandbox.restore();
+  }
+});
+
+test('hasMany() helper sets up a promise proxy to a related resource', function(assert) {
+  let author = this.container.lookupFactory('model:authors').create({
+    id: '1', attributes: { name: 'pixelhandler' },
+    relationships: {
+      posts: {
+        links: {
+          "self": "http://api.pixelhandler.com/api/v1/authors/1/relationships/posts",
+          "related": "http://api.pixelhandler.com/api/v1/authors/1/posts"
+        }
+      }
+    }
+  });
+  this.container.lookupFactory('model:posts').create({
+    id: '2', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
+    relationships: {
+      author: {
+        data: { type: 'authors', id: '1' },
+        links: {
+          'self': 'http://api.pixelhandler.com/api/v1/posts/2/relationships/author',
+          'related': 'http://api.pixelhandler.com/api/v1/posts/2/author'
+        }
+      },
+    }
+  });
+  let promise = author.get('posts');
+  assert.ok(promise.toString().match('ArrayProxy').length === 1, 'ArrayProxy used for hasMany relation');
+});

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -1,0 +1,60 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
+import { setup, teardown } from 'dummy/tests/helpers/resources';
+
+let mockServices;
+const mockService = function () {
+  let sandbox = this.sandbox;
+  return Ember.Service.extend({
+    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(null); }),
+    cacheLookup: sandbox.spy(function () { return []; })
+  });
+};
+let entities = ['post', 'author'];
+
+moduleFor('model:resource', 'Unit | Utility | hasOne', {
+  beforeEach() {
+    setup.call(this);
+    this.sandbox = window.sinon.sandbox.create();
+    mockServices = {};
+    entities.forEach(function (entity) {
+      let serviceName = pluralize(entity);
+      mockServices[serviceName] = mockService.call(this);
+      this.registry.register('service:'+serviceName, mockServices[serviceName]);
+    }.bind(this));
+  },
+  afterEach() {
+    mockServices = null;
+    teardown();
+    this.sandbox.restore();
+  }
+});
+
+test('hasOne() helper sets up a promise proxy to a related resource', function(assert) {
+  let post = this.container.lookupFactory('model:posts').create({
+    id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
+    relationships: {
+      author: {
+        data: { type: 'authors', id: '2' },
+        links: {
+          'self': 'http://api.pixelhandler.com/api/v1/posts/1/relationships/author',
+          'related': 'http://api.pixelhandler.com/api/v1/posts/1/author'
+        }
+      },
+    }
+  });
+  this.container.lookupFactory('model:authors').create({
+    id: '2', attributes: { name: 'Bill' },
+    relationships: {
+      posts: {
+        links: {
+          "self": "http://api.pixelhandler.com/api/v1/authors/2/relationships/posts",
+          "related": "http://api.pixelhandler.com/api/v1/authors/2/posts"
+        }
+      }
+    }
+  });
+  let promise = post.get('author');
+  assert.ok(promise.toString().match('ObjectProxy').length === 1, 'ObjectProxy used for hasOne relation');
+});

--- a/tests/unit/utils/is-test.js
+++ b/tests/unit/utils/is-test.js
@@ -1,0 +1,59 @@
+import { isBlank, isDasherized, isType } from 'ember-jsonapi-resources/utils/is';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | is');
+
+test('#isBlank null, undefined', function(assert) {
+  assert.ok(isBlank(null), 'null is blank');
+  assert.ok(isBlank(undefined), 'undefined is blank');
+});
+
+test('#isBlank primitives: string, number, boolean', function(assert) {
+  assert.ok(!isBlank('Wild West'), 'A string (with length) is not blank');
+  assert.ok(!isBlank(''), 'A string (with no length) is not blank');
+
+  assert.ok(!isBlank(1848), 'A (postive) number is not blank');
+  assert.ok(!isBlank(0), 'A (zero) number is not blank');
+  assert.ok(!isBlank(-1), 'A (negative) number is not blank');
+  assert.ok(!isBlank(0.25), 'A (float) number is not blank');
+
+  assert.ok(!isBlank(false), 'A (false) boolean is not blank');
+  assert.ok(!isBlank(true), 'A (true) boolean is not blank');
+});
+
+test('#isBlank complex: date, object, array', function(assert) {
+  assert.ok(!isBlank(new Date('1848')), 'A date is not blank');
+  assert.ok(!isBlank({}), 'An empty object is not blank');
+  assert.ok(!isBlank({name: 'Joe'}), 'An object (with props) is not blank');
+  assert.ok(!isBlank(['Sue']), 'An array (with length) is not blank');
+});
+
+test('#isDasherized', function(assert) {
+  assert.ok(isDasherized('is-dashed'), 'is-dashed is dasherized');
+  assert.ok(!isDasherized('camelCased'), 'camelCased is not dasherized');
+  assert.ok(!isDasherized('snake_case'), 'snake_case is not dasherized');
+});
+
+test('#isType - string', function(assert) {
+  assert.ok(isType('string', 'Los Angeles, CA'), 'value is a string');
+});
+
+test('#isType - number', function(assert) {
+  assert.ok(isType('number', 1901), 'value is a number');
+});
+
+test('#isType - boolean', function(assert) {
+  assert.ok(isType('boolean', true), 'value is a boolean');
+});
+
+test('#isType - date', function(assert) {
+  assert.ok(isType('date', new Date('1848')), 'value is a date');
+});
+
+test('#isType - object', function(assert) {
+  assert.ok(isType('object', {}), 'value is an object');
+});
+
+test('#isType - array', function(assert) {
+  assert.ok(isType('array', []), 'value is an array');
+});


### PR DESCRIPTION
- string, number, boolean, date, object, array may be set as the type of attribute
- reorganize modules for Resource helpers into utilities
- use `constructor.metaForProperty` instead of `proto._meta` for lookup of computed property meta values
- update README with use of attr() and optional types