### PR TITLE
Add transform methods for [de]serializing resource attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,17 @@ a specific specification for an API server without the need for an abstraction.
 
 **Does this implement all of the JSON API specification?**
 
-**Not yet**. The happy path for reading, creating, updating/patching, deleting
+**Most of it**. The happy path for reading, creating, updating/patching, deleting
 is ready, as well as patching relationships. No extension support has been worked
 on, e.g. [JSON Patch]. I would like to do that one day.
 
 **Is this lightweight? Relative to what?**
 
 **Yes**. With a server that follows the JSON API specification - it just works.
-This is a simple solution compared with starting from scratch using AJAX, or
-adapting Ember Data to work with the URLs. This solution provides a basic,
-timed caching solution to minimize requests, and leaves a more advanced caching
-strategy to the developer via a mixin. It does provide a `store` object that
-caches deserialized resources.
+This is a simple solution compared with starting from scratch using AJAX. This
+solution provides a basic, (timed) caching solution to minimize requests, and
+leaves a more advanced caching strategy to the developer via a mixin. It does
+provide a `store` object that caches deserialized resources.
 
 **Are included resources supported (side-loading)?**
 
@@ -259,11 +258,11 @@ Here is the blueprint for a `resource` (model) prototype:
 
 ```javascript
 import Ember from 'ember';
-import Resource from 'ember-jsonapi-resources/models/resource';
+import Resource from './resource';
 import { attr, hasOne, hasMany } from 'ember-jsonapi-resources/models/resource';
 
 export default Resource.extend({
-  type: '<%= entity %>',
+  type: '<%= resource %>',
   service: Ember.inject.service('<%= resource %>'),
 
   /*
@@ -281,7 +280,17 @@ export default Resource.extend({
 });
 ```
 
-The commented out code is an example of how to setup the relationships.
+The commented out code includes an example of how to setup the relationships
+and define your attributes. `attr()` can be used for any valid type, or you can
+specify a type, e.g. `attr('string')` or `attr('date')`. An attribute that is
+defined as a `'date'` type has a built in transform method to serialize and
+deserialize the date value. Typically the JSON value for a Date object is
+communicated in ISO format, e.g. "2015-08-25T22:05:37.393Z". The application
+serializer has methods for [de]serializing the date values between client and
+server. You can add your own transform methods based on the type of the
+attribute or based on the name of the attribute, the transform methods based on
+the name of the attribute will be called instead of any transform methods based
+on the type of the attribute.
 
 The relationships are async using promise proxy objects. So when a template accesses 
 the `resource`'s relationship a request is made for the relation.
@@ -309,6 +318,8 @@ var ENV = {
 // …
 };
 ```
+
+`MODEL_FACTORY_INJECTIONS` may be already set to `true` in the app/app.js file.
 
 Also, once you've generated a `resource` you can assign the URL.
 
@@ -342,7 +353,9 @@ as needed to act as if the API server is running on your same domain.
 
 #### Authorization
 
-EJR by default will pick-up credentials saved on `localStorage['AuthorizationHeader']`. If you'd like to change this, for instance to make it work with `ember-simple-auth`, there's a [configurable mixin available](https://github.com/pixelhandler/ember-jsonapi-resources/wiki/Authorization).
+By default credentials stored at `localStorage['AuthorizationHeader']` will be used.
+If you'd like to change this, for instance to make it work with `ember-simple-auth`,
+there's a [configurable mixin available](https://github.com/pixelhandler/ember-jsonapi-resources/wiki/Authorization).
 
 #### Example JSON API 1.0 Document
 

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -231,6 +231,7 @@ export default Ember.Object.extend(Ember.Evented, {
           return resp.json().then(function(json) {
             if (isUpdate) {
               _this.cacheUpdate({ meta: json.meta, data: json.data, headers: resp.headers });
+              json.data = _this.serializer.transformAttributes(json.data);
               resolve(json.data);
             } else {
               const resource = _this.serializer.deserialize(json);

--- a/addon/mixins/transforms.js
+++ b/addon/mixins/transforms.js
@@ -1,0 +1,27 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule transforms
+**/
+
+import Ember from 'ember';
+import { dateTransform } from 'ember-jsonapi-resources/utils/transforms';
+
+export default Ember.Mixin.create({
+  /**
+    @method serializeDateAttribute
+    @param {Date|String} date
+    @return {String|Null} date value as ISO String for JSON payload, or null
+  */
+  serializeDateAttribute(date) {
+    return dateTransform.serialize(date);
+  },
+
+  /**
+    @method deserializeDateAttribute
+    @param {String} date usually in ISO format, must be a valid argument for Date
+    @return {Date|Null} date value from JSON payload, or null
+  */
+  deserializeDateAttribute(date) {
+    return dateTransform.deserialize(date);
+  }
+});

--- a/addon/utils/transforms.js
+++ b/addon/utils/transforms.js
@@ -1,0 +1,45 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule utils
+**/
+
+import { isBlank, isType } from 'ember-jsonapi-resources/utils/is';
+
+/**
+  @class TransformDateAttribute
+*/
+class TransformDateAttribute {
+
+  /**
+    @method serialize
+    @param {Date|String} date
+    @return {String|Null} date value as ISO String for JSON payload, or null
+  */
+  serialize(date) {
+    if (isBlank(date) || date === '') {
+      date = null;
+    } else if (isType('date', date)) {
+      date = date.toISOString();
+    } else if (isType('string', date)) {
+      date = new Date(date);
+    }
+    return (date) ? date : null;
+  }
+
+  /**
+    @method serialize
+    @param {String} date usually in ISO format, must be a valid argument for Date
+    @return {Date|Null} date value from JSON payload, or null
+  */
+  deserialize(date) {
+    if (isBlank(date)) {
+      date = null;
+    } else if (isType('string', date) || isType('number', date)) {
+      date = new Date(date);
+    }
+    return (date) ? date : null;
+  }
+
+}
+
+export let dateTransform = new TransformDateAttribute();

--- a/app/mixins/transforms.js
+++ b/app/mixins/transforms.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-jsonapi-resources/mixins/transforms';

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,1 +1,10 @@
-export { default } from 'ember-jsonapi-resources/serializers/application';
+import TransformsMixin from '../mixins/transforms';
+import ApplicationSerializer from 'ember-jsonapi-resources/serializers/application';
+
+/**
+  Serializer for a JSON API resource, combines the addon ApplicationSerializer and TransformsMixin
+
+  @class ApplicationSerializer
+  @uses TransformsMixin
+*/
+export default ApplicationSerializer.extend(TransformsMixin);

--- a/fixtures/api/posts/1.json
+++ b/fixtures/api/posts/1.json
@@ -10,7 +10,9 @@
       "slug": "practical-deploy-an-ember-app-with-ember-cli-deploy-on-digitalocean",
       "excerpt": "The notes below demonstrate how to setup a chat application, built with [Ember CLI], that uses a backend service from [Firebase].",
       "date": "2015-04-25",
-      "body": "## Lightning-Approach Workflow\n\nThis approach is the default setup when using ember-cli-deploy and uses a Redis\nstore for the versions of your index.html file that you deploy."
+      "body": "## Lightning-Approach Workflow\n\nThis approach is the default setup when using ember-cli-deploy and uses a Redis\nstore for the versions of your index.html file that you deploy.",
+      "created-at": "2015-04-25T00:00:00.000Z",
+      "updated-at": "2015-04-25T00:00:00.000Z"
     },
     "relationships": {
       "author": {

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -1,7 +1,8 @@
 import ApplicationAdapter from './application';
 import config from '../config/environment';
+import AuthorizationMixin from '../mixins/authorization';
 
-export default ApplicationAdapter.extend({
+export default ApplicationAdapter.extend(AuthorizationMixin, {
   type: 'post',
 
   url: config.APP.API_PATH + '/posts',

--- a/tests/dummy/app/models/author.js
+++ b/tests/dummy/app/models/author.js
@@ -6,8 +6,8 @@ export default Resource.extend({
   type: 'author',
   service: Ember.inject.service('authors'),
 
-  name: attr(),
-  email: attr(),
+  name: attr('string'),
+  email: attr('string'),
 
   posts: hasMany('posts')
 });

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -6,7 +6,7 @@ export default Resource.extend({
   type: 'comment',
   service: Ember.inject.service('comments'),
 
-  body: attr(),
+  body: attr('string'),
 
   date: Ember.computed('attributes', {
     get() {

--- a/tests/dummy/app/models/commenter.js
+++ b/tests/dummy/app/models/commenter.js
@@ -6,8 +6,8 @@ export default Resource.extend({
   type: 'commenter',
   service: Ember.inject.service('commenters'),
 
-  name: attr(),
-  email: attr(),
+  name: attr('string'),
+  email: attr('string'),
   hash: attr(),
 
   comments: hasMany('comments')

--- a/tests/dummy/app/models/employee.js
+++ b/tests/dummy/app/models/employee.js
@@ -6,7 +6,7 @@ export default Resource.extend({
   type: 'employees',
   service: Ember.inject.service('employees'),
 
-  name: attr(),
+  name: attr('string'),
 
   pictures: hasMany('pictures')
 });

--- a/tests/dummy/app/models/picture.js
+++ b/tests/dummy/app/models/picture.js
@@ -6,7 +6,9 @@ export default Resource.extend({
   type: 'pictures',
   service: Ember.inject.service('pictures'),
 
-  name: attr(),
+  "name": attr('string'),
+  "updated-at": attr('date'),
+  "created-at": attr('date'),
 
   imageable: hasOne('imageable') // polymorphic
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -6,9 +6,9 @@ export default Resource.extend({
   type: 'post',
   service: Ember.inject.service('posts'),
 
-  title: attr(),
+  title: attr('string'),
   date: attr(),
-  excerpt: attr(),
+  excerpt: attr('string'),
 
   author: hasOne('author'),
   comments: hasMany('comments')

--- a/tests/dummy/app/models/product.js
+++ b/tests/dummy/app/models/product.js
@@ -6,7 +6,7 @@ export default Resource.extend({
   type: 'products',
   service: Ember.inject.service('products'),
 
-  name: attr(),
+  name: attr('string'),
 
   pictures: hasMany('pictures')
 });

--- a/tests/dummy/app/templates/pictures/detail.hbs
+++ b/tests/dummy/app/templates/pictures/detail.hbs
@@ -1,4 +1,7 @@
-<p>Name: {{model.name}}</p>
+<p>
+  Name: {{model.name}}<br>
+  Updated At: {{model.updated-at}}
+</p>
 <p>Imageable: {{model.imageable.name}}</p>
 
 {{outlet}}

--- a/tests/helpers/resources.js
+++ b/tests/helpers/resources.js
@@ -3,34 +3,36 @@ import { attr, hasOne, hasMany } from 'ember-jsonapi-resources/models/resource';
 
 export const Post = Resource.extend({
   type: 'posts',
-  title: attr(),
-  excerpt: attr(),
+  title: attr('string'),
+  excerpt: attr('string'),
+  "updated-at": attr('date'),
+  "created-at": attr('date'),
   author: hasOne('author'),
   comments: hasMany('comments')
 });
 
 export const Author = Resource.extend({
   type: 'authors',
-  name: attr(),
+  name: attr('string'),
   posts: hasMany('posts')
 });
 
 export const Comment = Resource.extend({
   type: 'comments',
-  body: attr(),
+  body: attr('string'),
   commenter: hasOne('commenter'),
   post: hasOne('post')
 });
 
 export const Commenter = Resource.extend({
   type: 'commenters',
-  name: attr(),
+  name: attr('string'),
   comments: hasMany('comments')
 });
 
 export const Person = Resource.extend({
   type: 'people',
-  name: attr()
+  name: attr() // can use any value type for an attribute
 });
 
 export const Employee = Person.extend({

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -235,6 +235,8 @@ test('#fetch calls #fetchURL to customize if needed', function(assert) {
 });
 
 test('#fetch calls #fetchOptions checking if the request is an update, if true skips call to deserialize', function(assert) {
+  const done = assert.async();
+  assert.expect(3);
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetchUrl', function () {});
   sandbox.stub(window, 'fetch', function () {
@@ -246,10 +248,14 @@ test('#fetch calls #fetchOptions checking if the request is an update, if true s
     });
   });
   sandbox.stub(adapter, 'cacheResource', function () {});
-  adapter.serializer = { deserialize: sandbox.spy() };
+  adapter.serializer = { deserialize: sandbox.spy(), transformAttributes: sandbox.spy() };
   let promise = adapter.fetch('/posts', { method: 'PATCH', body: 'json string here', update: true });
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
-  assert.equal(adapter.serializer.deserialize.callCount, 0, '#deserialize method NOT called');
+  promise.then(function() {
+    assert.equal(adapter.serializer.deserialize.callCount, 0, '#deserialize method NOT called');
+    assert.equal(adapter.serializer.transformAttributes.callCount, 1, '#transformAttributes method called');
+    done();
+  });
 });
 
 test('#fetchUrl', function(assert) {

--- a/tests/unit/mixins/transforms-test.js
+++ b/tests/unit/mixins/transforms-test.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+import TransformsMixin from 'ember-jsonapi-resources/mixins/transforms';
+import { module, test } from 'qunit';
+import { dateTransform } from 'ember-jsonapi-resources/utils/transforms';
+
+let sandbox;
+
+module('Unit | Mixin | transforms', {
+  beforeEach() {
+    let Transforms = Ember.Object.extend(TransformsMixin);
+    this.subject = Transforms.create();
+    sandbox = window.sinon.sandbox.create();
+  },
+  afterEach() {
+    sandbox.restore();
+    delete this.subject;
+  }
+});
+
+test('#serializeDateAttribute', function(assert) {
+  sandbox.stub(dateTransform, 'serialize');
+  this.subject.serializeDateAttribute(new Date());
+  assert.ok(dateTransform.serialize.calledOnce, 'called date transform serialize method');
+});
+
+test('#deserializeDateAttribute', function(assert) {
+  sandbox.stub(dateTransform, 'deserialize');
+  this.subject.deserializeDateAttribute( (new Date()).toISOString() );
+  assert.ok(dateTransform.deserialize.calledOnce, 'called date transform deserialize method');
+});

--- a/tests/unit/utils/transforms-test.js
+++ b/tests/unit/utils/transforms-test.js
@@ -1,0 +1,20 @@
+import { dateTransform } from 'ember-jsonapi-resources/utils/transforms';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | transforms');
+
+test('dateTransform#serialize - to ISO String', function(assert) {
+  let date = 'October 26, 1881';
+  let gunfightAtOKCorral = new Date(date);
+  let expected = gunfightAtOKCorral.toISOString();
+  let serialized = dateTransform.serialize(gunfightAtOKCorral);
+  assert.equal(serialized, expected, 'serialized to ISO String');
+});
+
+test('dateTransform#deserialize - from ISO String', function(assert) {
+  let date = 'October 26, 1881';
+  let gunfightAtOKCorral = new Date(date);
+  let value = gunfightAtOKCorral.toISOString();
+  let deserialized = dateTransform.deserialize(value);
+  assert.equal(deserialized.valueOf(), gunfightAtOKCorral.valueOf(), 'deserialized from ISO String');
+});


### PR DESCRIPTION
The application serializer has methods for [de]serializing the date values between client and server. An attribute that is setup as a `'date'` type also has a built in transform method to serialize and deserialize the date value. Typically the JSON value for a Date object is communicated in ISO format, e.g. "2015-08-25T22:05:37.393Z". 

The TransformsMixin defines `serializeDateAttribute` and `deserializeDateAttribute`. Any valid type can be added to your app, just generate a `transforms` mixin and define other types if needed. Or when you generate a resource add the type specific methods or attribute name specific methods on the serializer prototype (class) for your resource.

The methods use a naming convention '[de]serialize' + 'AttrName' or 'TypeName' + 'Attribute'; so to add a specific method to transform a name value for an author resource add two methods:

```js
import ApplicationSerializer from './application';

export default ApplicationSerializer.extend({
  serializeNameAttribute(value) {
    return value.split('written by: ')[1];
  },
  deserializeNameAttribute(value) {
    return 'written by: ' + value;
  },
});
```

Or, to handle a date type transform differently than the default to/from ISO format transformation:

```js
import ApplicationSerializer from './application';

export default ApplicationSerializer.extend({
  serializeDateAttribute(date) {
    return /* serialized format from your resource attribute value, for use on your API server */;
  },
  deserializeDateAttribute(date) {
    return /* deserialized format from your API server, for use in your client app*/;
  },
});
```

You can add your own transform methods based on the type of the attribute or based on the name of the attribute, the transform methods based on the name of the attribute will be called instead of any transform methods based on the type of the attribute.