### PR TITLE
Resource updates, new behavior for relations

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -164,7 +164,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
     Patch a relationship, either add or remove, sends a PATCH request
 
     Adds with payload: `{ "data": { "type": "comments", "id": "12" } }`
-    Removes with payload: `{ "data": null }`
+    Removes with payload: `{ "data": null }` for to-one or `{ "data": [] }` for to-many
 
     @method patchRelationship
     @param {Resource} the resource instance, has URLs via it's relationships property
@@ -245,6 +245,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
   fetchOptions(options) {
     let isUpdate;
     options.headers = options.headers || { 'Content-Type': 'application/vnd.api+json' };
+    options.credentials = options.credentials || 'same-origin';
     this.fetchAuthorizationHeader(options);
     if (typeof options.update === 'boolean') {
       isUpdate = options.update;

--- a/addon/mixins/fetch.js
+++ b/addon/mixins/fetch.js
@@ -8,7 +8,7 @@ import Ember from 'ember';
   Fetch/Ajax methods for use with an Adapter calls `cacheUpdate`, `cacheResource`
   methods and a `serializer` injection.
 
-  @class Fetch
+  @class FetchMixin
 */
 export default Ember.Mixin.create({
   /**

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -74,8 +74,8 @@ export default Ember.Service.extend({
 
     @method patchRelationship
     @param {String} type - the entity or resource name will be pluralized
-    @param {Resource} the resource instance, has URLs via it's relationships property
-    @param {String} resource name (plural) to find the url from the resource instance
+    @param {Resource} resource - model instance, has URLs via it's relationships property
+    @param {String} relationship - resource name (plural) to find the url from the resource instance
     @return {Promise}
   */
   patchRelationship(type, resource, relationship) {

--- a/addon/utils/has-many.js
+++ b/addon/utils/has-many.js
@@ -49,7 +49,7 @@ export default function hasMany(relation) {
   let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
   let path = linksPath(relation);
   return Ember.computed(path, function () {
-    return util.createProxy(this, Ember.ArrayProxy);
+    return util.createProxy(this, 'many');
   }).meta({relation: relation, type: type, kind: 'hasMany'});
 }
 

--- a/addon/utils/has-one.js
+++ b/addon/utils/has-one.js
@@ -48,7 +48,7 @@ export default function hasOne(relation) {
   let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
   let path = linksPath(relation);
   return Ember.computed(path, function () {
-    return util.createProxy(this, Ember.ObjectProxy);
+    return util.createProxy(this, 'one');
   }).meta({relation: relation, type: type, kind: 'hasOne'});
 }
 


### PR DESCRIPTION
- New resource uses mock relation in proxy relationship hasOne/hasMany
- Add Update Relationship method to Resource prototype
- Add header for `credentials` in fetch options (support for cookie session)

When a resource `isNew` has a `true` value (default is `false`) the resource does not yet have any URLs from the server. Since it's the server's job to inform that client of the relationship URLs a new resource will only use the [resource identifier objects](http://jsonapi.org/format/#document-resource-identifier-objects). The new Resource#updateRelationships object manages changes to the relationships data object(s).

By using the `Resource#updateRelationship` method you may update a relation by adding or removing using a list, id, or null. When adding an id for a to-many relation send one or more ids, include the existing ids as well. When removing from a to-many relation pass the ids that should remain, missing ids will be removed, or remove all with an empty array. When operating on a to-one relation just use the id to change the relation, or null to remove.