### PR TITLE
Adapter#createResource may set props of resource instance

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -121,7 +121,8 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
   },
 
   /**
-    Create a new resource, sends a POST request
+    Create a new resource, sends a POST request, updates resource instance
+    with persisted data, and updates cache with persisted resource
 
     @method createResource
     @param {Resource} the resource instance to serialize
@@ -133,7 +134,17 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
     return this.fetch(url, {
       method: 'POST',
       body: JSON.stringify(json)
-    });
+    }).then(function(resp) {
+      if (resource.toString().match('JSONAPIResource') === null) {
+        return resp;
+      } else {
+        resource.set('id', resp.get('id') );
+        let json = resp.getProperties('attributes', 'relationships', 'links', 'meta', 'type', 'isNew');
+        resource.didUpdateResource(json);
+        this.cacheUpdate({ data: resource });
+        return resource;
+      }
+    }.bind(this));
   },
 
   /**


### PR DESCRIPTION
The Adapter#createResource method accepts a resource argument, which is flexible to work with either a Resource instance or a plain object that represents a JSON API Resource.

Given the `createResource` method is called with a `Resource` (model) instance, use `then()` to update the resource instance and ensure the cached resource is same resource. (May replace a newly created resource by the deserialize method.)