### PR TITLE
Update cache handling for updates, remove evented update callbacks

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -148,9 +148,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
   },
 
   /**
-    Patch an existing resource, sends a PATCH request. After promise is resolved
-    the `didUpdateResource` event is triggered, given an error response a event
-    `resourceError` is triggered. A resource may listen on its `service` reference.
+    Patch an existing resource, sends a PATCH request.
 
     @method updateResource
     @param {Resource} the resource instance to serialize the changed attributes
@@ -164,11 +162,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
       method: 'PATCH',
       body: JSON.stringify(json),
       update: true
-    }).then(function(json) {
-      this.trigger('didUpdateResource', json);
-    }.bind(this)).catch(function(resp) {
-      this.trigger('resourceError', resp);
-    }.bind(this));
+    });
   },
 
   /**
@@ -190,9 +184,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
     return this.fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(data)
-    }).then(function(json) {
-      this.trigger('didUpdateRelationship', json);
-    }.bind(this));
+    });
   },
 
   /**

--- a/addon/mixins/service-cache.js
+++ b/addon/mixins/service-cache.js
@@ -98,18 +98,20 @@ export default Ember.Mixin.create({
     if (!Array.isArray(resp.data) && typeof resp.data === 'object') {
       resp.data = [ resp.data ];
     }
-    let index, id;
+    let index, id, item, isResourceType;
     for (let i = 0; i < resp.data.length; i++) {
       id = resp.data[i].id || resp.data[i].get('id');
       index = ids.indexOf(id);
-      if (resp.data[i].toString().indexOf('JSONAPIResource') > -1) {
-        if (index === -1) {
-          this.cache.data.pushObject(resp.data[i]);
-        } else {
-          this.cache.data.replaceContent(index, 1, resp.data[i]);
-        }
+      isResourceType = resp.data[i].toString().indexOf('JSONAPIResource') > -1;
+      if (index === -1 && isResourceType) {
+        this.cache.data.pushObject(resp.data[i]);
+      } else if (isResourceType) {
+        this.cache.data.replaceContent(index, 1, resp.data[i]);
+      } else if (index > -1) {
+        item = this.cache.data.findBy('id', id);
+        item.didUpdateResource(resp.data[i]);
       }
-      this.cacheControl(this.cache.data.findBy('id', id), resp.headers);
+      this.cacheControl(item || this.cache.data.findBy('id', id), resp.headers);
     }
   },
 

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -253,19 +253,8 @@ const Resource = Ember.Object.extend({
   }).volatile(),
 
   /**
-    Initialize events to communicate with the service object, listen for `didUpdateResource`
-
-    @method initEvents
-  */
-  initEvents: Ember.on('init', function () {
-    const service = this.get('service');
-    if (service) {
-      service.on('didUpdateResource', this, this.didUpdateResource);
-    }
-  }),
-
-  /**
-    Handler for `didUpdateResource` event, resets private _attributes used for changed/previous tracking
+    Sets all payload properties on the resource and resets private _attributes
+    used for changed/previous tracking
 
     @method didUpdateResource
     @param json the updated data for the resource

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -396,8 +396,8 @@ test('#fetch handles 4xx (Client Error) response status', function(assert) {
   sandbox.stub(window, 'fetch', function () {
     return Ember.RSVP.Promise.resolve({
       "status": 404,
-      "json": function() {
-        return Ember.RSVP.Promise.resolve({ errors: [ { code: 404 } ] });
+      "text": function() {
+        return Ember.RSVP.Promise.resolve("{ errors: [ { status: 404 } ] }");
       }
     });
   });
@@ -406,7 +406,7 @@ test('#fetch handles 4xx (Client Error) response status', function(assert) {
   promise.catch(function(error) {
     assert.ok(error.name, 'Client Error', '4xx response throws a custom error');
     assert.ok(Array.isArray(error.errors), '4xx error includes errors');
-    assert.equal(error.errors[0].code, 404, '404 error code is in errors list');
+    assert.equal(error.errors[0].status, 404, '404 error status is in errors list');
     done();
   });
 });

--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -56,14 +56,6 @@ test('it has properties for changed/previous attributes', function(assert) {
   });
 });
 
-test('it has methods for communication on an event bus with service', function(assert) {
-  const resource = this.subject();
-  let methods = Ember.String.w('initEvents didUpdateResource');
-  methods.forEach(function (method) {
-    assert.ok(typeof resource[method] === 'function', 'resource#' + method + ' is a function');
-  });
-});
-
 test('it needs a reference to an injected service object', function(assert) {
   const resource = this.subject();
   assert.ok(resource.get('service') === null, 'resource#service is null by default');


### PR DESCRIPTION
- (Breaking change) Removing event triggers `didUpdateResource` and `resourceError`
- Cache update after updating a resource (PATCH) is handled by model method, via `cacheUpdate`
- Support (client, 40x) text error response, parse text to JSON