### PR TITLE
Simplify initializer, use standard naming for factories

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -139,7 +139,7 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
         return resp;
       } else {
         resource.set('id', resp.get('id') );
-        let json = resp.getProperties('attributes', 'relationships', 'links', 'meta', 'type', 'isNew');
+        let json = resp.getProperties('attributes', 'relationships', 'links', 'meta', 'type', 'isNew', 'id');
         resource.didUpdateResource(json);
         this.cacheUpdate({ data: resource });
         return resource;

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -329,8 +329,8 @@ Resource.reopenClass({
     if (properties) {
       instance.setProperties(properties);
     }
-    let type = instance.get('type');
-    let msg = (type) ? Ember.String.capitalize(singularize(type)) : 'Resource';
+    let type = singularize(instance.get('type'));
+    let msg = (type) ? Ember.String.capitalize(type) : 'Resource';
     let factory = 'model:' + type;
     if (!type) {
       Ember.Logger.warn(msg + '#create called, instead you should first use ' + msg + '.extend({type:"entity"})');

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -4,7 +4,7 @@
 **/
 
 import Ember from 'ember';
-import { pluralize } from 'ember-inflector';
+import { singularize, pluralize } from 'ember-inflector';
 
 /**
   Serializer/Deserializer for a JSON API resource object, used by adapter.
@@ -238,7 +238,7 @@ export default Ember.Object.extend({
     @return {Function} factory for creating resource instances
   */
   _lookupFactory(type) {
-    return this.container.lookupFactory('model:' + type);
+    return this.container.lookupFactory('model:' + singularize(type));
   }
 });
 

--- a/blueprints/jsonapi-initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/jsonapi-initializer/files/__root__/initializers/__name__.js
@@ -1,18 +1,9 @@
-import Service from '<%= servicePath %>';
-import Model from '<%= modelPath %>';
-import Adapter from '<%= adapterPath %>';
-import Serializer from '<%= serializerPath %>';
-
 export function initialize() {
   // see http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
   let application = arguments[1] || arguments[0];
-  application.register('model:<%= resource %>', Model, { instantiate: false, singleton: false });
-  application.register('service:<%= resource %>', Service);
-  application.register('adapter:<%= resource %>', Adapter);
-  application.register('serializer:<%= resource %>', Serializer);
 
   application.inject('service:store', '<%= resource %>', 'service:<%= resource %>');
-  application.inject('service:<%= resource %>', 'serializer', 'serializer:<%= resource %>');
+  application.inject('service:<%= resource %>', 'serializer', 'serializer:<%= entity %>');
 }
 
 export default {

--- a/tests/dummy/app/initializers/author.js
+++ b/tests/dummy/app/initializers/author.js
@@ -1,17 +1,8 @@
-import Service from '../services/authors';
-import Model from '../models/author';
-import Adapter from '../adapters/author';
-import Serializer from '../serializers/author';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:authors', Model, { instantiate: false, singleton: false });
-  application.register('service:authors', Service);
-  application.register('adapter:authors', Adapter);
-  application.register('serializer:authors', Serializer);
 
   application.inject('service:store', 'authors', 'service:authors');
-  application.inject('service:authors', 'serializer', 'serializer:authors');
+  application.inject('service:authors', 'serializer', 'serializer:author');
 }
 
 export default {

--- a/tests/dummy/app/initializers/comment.js
+++ b/tests/dummy/app/initializers/comment.js
@@ -1,17 +1,8 @@
-import Service from '../services/comments';
-import Model from '../models/comment';
-import Adapter from '../adapters/comment';
-import Serializer from '../serializers/comment';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:comments', Model, { instantiate: false, singleton: false });
-  application.register('service:comments', Service);
-  application.register('adapter:comments', Adapter);
-  application.register('serializer:comments', Serializer);
 
   application.inject('service:store', 'comments', 'service:comments');
-  application.inject('service:comments', 'serializer', 'serializer:comments');
+  application.inject('service:comments', 'serializer', 'serializer:comment');
 }
 
 export default {

--- a/tests/dummy/app/initializers/commenter.js
+++ b/tests/dummy/app/initializers/commenter.js
@@ -1,17 +1,8 @@
-import Service from '../services/commenters';
-import Model from '../models/commenter';
-import Adapter from '../adapters/commenter';
-import Serializer from '../serializers/commenter';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:commenters', Model, { instantiate: false, singleton: false });
-  application.register('service:commenters', Service);
-  application.register('adapter:commenters', Adapter);
-  application.register('serializer:commenters', Serializer);
 
   application.inject('service:store', 'commenters', 'service:commenters');
-  application.inject('service:commenters', 'serializer', 'serializer:commenters');
+  application.inject('service:commenters', 'serializer', 'serializer:commenter');
 }
 
 export default {

--- a/tests/dummy/app/initializers/employee.js
+++ b/tests/dummy/app/initializers/employee.js
@@ -1,17 +1,8 @@
-import Service from '../services/employees';
-import Model from '../models/employee';
-import Adapter from '../adapters/employee';
-import Serializer from '../serializers/employee';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:employees', Model, { instantiate: false, singleton: false });
-  application.register('service:employees', Service);
-  application.register('adapter:employees', Adapter);
-  application.register('serializer:employees', Serializer);
 
   application.inject('service:store', 'employees', 'service:employees');
-  application.inject('service:employees', 'serializer', 'serializer:employees');
+  application.inject('service:employees', 'serializer', 'serializer:employee');
 }
 
 export default {

--- a/tests/dummy/app/initializers/imageable.js
+++ b/tests/dummy/app/initializers/imageable.js
@@ -1,15 +1,8 @@
-import Service from '../services/imageables';
-import Adapter from '../adapters/imageable';
-import Serializer from '../serializers/application';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('service:imageables', Service);
-  application.register('adapter:imageables', Adapter);
-  application.register('serializer:imageables', Serializer);
 
   application.inject('service:store', 'imageables', 'service:imageables');
-  application.inject('service:imageables', 'serializer', 'serializer:imageables');
+  application.inject('service:imageables', 'serializer', 'serializer:imageable');
 }
 
 export default {

--- a/tests/dummy/app/initializers/picture.js
+++ b/tests/dummy/app/initializers/picture.js
@@ -1,17 +1,8 @@
-import Service from '../services/pictures';
-import Model from '../models/picture';
-import Adapter from '../adapters/picture';
-import Serializer from '../serializers/picture';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:pictures', Model, { instantiate: false, singleton: false });
-  application.register('service:pictures', Service);
-  application.register('adapter:pictures', Adapter);
-  application.register('serializer:pictures', Serializer);
 
   application.inject('service:store', 'pictures', 'service:pictures');
-  application.inject('service:pictures', 'serializer', 'serializer:pictures');
+  application.inject('service:pictures', 'serializer', 'serializer:picture');
 }
 
 export default {

--- a/tests/dummy/app/initializers/post.js
+++ b/tests/dummy/app/initializers/post.js
@@ -1,17 +1,8 @@
-import Service from '../services/posts';
-import Model from '../models/post';
-import Adapter from '../adapters/post';
-import Serializer from '../serializers/post';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:posts', Model, { instantiate: false, singleton: false });
-  application.register('service:posts', Service);
-  application.register('adapter:posts', Adapter);
-  application.register('serializer:posts', Serializer);
 
   application.inject('service:store', 'posts', 'service:posts');
-  application.inject('service:posts', 'serializer', 'serializer:posts');
+  application.inject('service:posts', 'serializer', 'serializer:post');
 }
 
 export default {

--- a/tests/dummy/app/initializers/product.js
+++ b/tests/dummy/app/initializers/product.js
@@ -1,17 +1,8 @@
-import Service from '../services/products';
-import Model from '../models/product';
-import Adapter from '../adapters/product';
-import Serializer from '../serializers/product';
-
 export function initialize() {
   let application = arguments[1] || arguments[0];
-  application.register('model:products', Model, { instantiate: false, singleton: false });
-  application.register('service:products', Service);
-  application.register('adapter:products', Adapter);
-  application.register('serializer:products', Serializer);
 
   application.inject('service:store', 'products', 'service:products');
-  application.inject('service:products', 'serializer', 'serializer:products');
+  application.inject('service:products', 'serializer', 'serializer:product');
 }
 
 export default {

--- a/tests/dummy/app/routes/admin/create.js
+++ b/tests/dummy/app/routes/admin/create.js
@@ -8,7 +8,7 @@ export default Ember.Route.extend({
   },
 
   model() {
-    return this.container.lookup('model:posts').create({
+    return this.container.lookup('model:post').create({
       isNew: true,
       attributes: { date: new Date() }
     });
@@ -23,8 +23,10 @@ export default Ember.Route.extend({
   actions: {
     save(resource) {
       this.store.createResource('posts', resource).then(function(resp) {
-        this.modelFor('admin.index').addObject(resp);
-        this.modelFor('index').addObject(resp);
+        let collection = this.modelFor('admin.index');
+        if (collection) { collection.addObject(resp); }
+        collection = this.modelFor('index');
+        if (collection) { collection.addObject(resp); }
         this.transitionTo('admin.index');
       }.bind(this));
     },

--- a/tests/helpers/resources.js
+++ b/tests/helpers/resources.js
@@ -48,19 +48,19 @@ export const Supervisor = Employee.extend({
 export function setup() {
   const opts = { instantiate: false, singleton: false };
   Post.prototype.container = this.container;
-  this.registry.register('model:posts', Post, opts);
+  this.registry.register('model:post', Post, opts);
   Author.prototype.container = this.container;
-  this.registry.register('model:authors', Author, opts);
+  this.registry.register('model:author', Author, opts);
   Comment.prototype.container = this.container;
-  this.registry.register('model:comments', Comment, opts);
+  this.registry.register('model:comment', Comment, opts);
   Commenter.prototype.container = this.container;
-  this.registry.register('model:commenters', Commenter, opts);
+  this.registry.register('model:commenter', Commenter, opts);
   Person.prototype.container = this.container;
-  this.registry.register('model:persons', Person, opts);
+  this.registry.register('model:person', Person, opts);
   Employee.prototype.container = this.container;
-  this.registry.register('model:employees', Employee, opts);
+  this.registry.register('model:employee', Employee, opts);
   Supervisor.prototype.container = this.container;
-  this.registry.register('model:supervisors', Supervisor, opts);
+  this.registry.register('model:supervisor', Supervisor, opts);
 }
 
 export function teardown() {

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -92,7 +92,7 @@ test('#findQuery calls #fetch url including a query', function(assert) {
 
 test('#findRelated', function(assert) {
   this.registry.register('service:authors', Adapter.extend({type: 'authors', url: '/authors'}));
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let url = resource.get( ['relationships', 'author', 'links', 'related'].join('.') );
   const adapter = this.subject({type: 'posts', url: '/posts'});
   let service = this.container.lookup('service:authors');
@@ -112,7 +112,7 @@ test('#findRelated can be called with optional type for the resource', function 
   this.registry.register('service:people', PersonAdapter.extend());
   let service = this.container.lookup('service:people');
   let stub = sandbox.stub(service, 'findRelated', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:employees').create({
+  let resource = this.container.lookupFactory('model:employee').create({
     type: 'employees',
     id: 1000001,
     name: 'The Special',
@@ -138,7 +138,7 @@ test('#createResource', function(assert) {
   assert.expect(6);
   let done = assert.async();
   const adapter = this.subject({type: 'posts', url: '/posts'});
-  let postFactory = this.container.lookupFactory('model:posts');
+  let postFactory = this.container.lookupFactory('model:post');
   let data = JSON.parse(JSON.stringify(postMock.data));
   delete data.id;
   let newResource = postFactory.create(data);
@@ -171,7 +171,7 @@ test('#updateResource', function(assert) {
   };
   adapter.serializer = { serializeChanged: function () { return payload; } };
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   assert.ok(adapter.fetch.calledOnce, '#fetch method called');
@@ -184,7 +184,7 @@ test('#updateResource returns null when serializer returns null (nothing changed
   const adapter = this.subject({type: 'posts', url: '/posts'});
   adapter.serializer = { serializeChanged: function () { return null; } };
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.equal(promise, null, 'null returned instead of promise');
   assert.ok(!adapter.fetch.calledOnce, '#fetch method NOT called');
@@ -193,7 +193,7 @@ test('#updateResource returns null when serializer returns null (nothing changed
 test('#patchRelationship (to-many)', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   resource.addRelationship('comments', '1');
   let promise = adapter.patchRelationship(resource, 'comments');
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -206,7 +206,7 @@ test('#patchRelationship (to-many)', function(assert) {
 test('#patchRelationship (to-one)', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   resource.addRelationship('author', '1');
   let promise = adapter.patchRelationship(resource, 'author');
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -228,7 +228,7 @@ test('#deleteResource can be called with a string as the id for the resource', f
 test('#deleteResource can be called with a resource having a self link, and calls resource#destroy', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   sandbox.stub(resource, 'destroy', function () {});
   let promise = adapter.deleteResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -241,7 +241,7 @@ test('#deleteResource can be called with a resource having a self link, and call
 test('when called with resource argument, #deleteResource calls #cacheRemove', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   sandbox.stub(adapter, 'cacheRemove', function () {});
   Ember.run(function() {
     adapter.deleteResource(resource);
@@ -339,7 +339,7 @@ test('#cacheUpdate called after #updateResource success', function(assert) {
     serializeChanged: function () { return payload; },
     transformAttributes: function(json) { return json; }
   };
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(function() {

--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -62,7 +62,7 @@ test('it needs a reference to an injected service object', function(assert) {
 });
 
 test('attr() uses the attributes hash for computed model attributes', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   assert.equal(post.get('title'), 'Wyatt Earp', 'name is set to "Wyatt Earp"');
@@ -98,7 +98,7 @@ test('attr() helper creates a computed property using a unique (protected) attri
 });
 
 test('#changedAttributes', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     attributes: {id: '1', title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   assert.equal(post.get('excerpt'), 'Was a gambler.', 'excerpt is set "Was a gambler."');
@@ -111,7 +111,7 @@ test('#changedAttributes', function(assert) {
 });
 
 test('#previousAttributes', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   assert.equal(post.get('excerpt'), 'Was a gambler.', 'title is set toGambler');
@@ -124,7 +124,7 @@ test('#previousAttributes', function(assert) {
 });
 
 test('#didUpdateResource empties the resource _attributes hash when resource id matches json arg id value', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.set('excerpt', 'became a deputy.');
@@ -134,7 +134,7 @@ test('#didUpdateResource empties the resource _attributes hash when resource id 
 });
 
 test('#didUpdateResource does nothing if json argument has an id that does not match the resource id', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.set('excerpt', 'became a deputy.');
@@ -144,13 +144,13 @@ test('#didUpdateResource does nothing if json argument has an id that does not m
 });
 
 test('#addRelationship', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.addRelationship('author', '2');
   let authorRelation = '{"author":{"links":{},"data":{"type":"authors","id":"2"}},"comments":{"links":{},"data":[]}}';
   assert.equal(JSON.stringify(post.get('relationships')), authorRelation, 'added relationship for author');
-  let comment = this.container.lookupFactory('model:comments').create({
+  let comment = this.container.lookupFactory('model:comment').create({
     id: '4',  attributes: {body: 'Wyatt become a deputy too.' },
     relationships: { commenter: { data: { type: 'commenter', id: '3' } } }
   });
@@ -163,26 +163,26 @@ test('#addRelationship', function(assert) {
 });
 
 test('#removeRelationship', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: { data: { type: 'authors', id: '2' } },
       comments: { data: [{ type: 'comments', id: '4' }] }
     }
   });
-  let author = this.container.lookupFactory('model:authors').create({
+  let author = this.container.lookupFactory('model:author').create({
     id: '2', attributes: { name: 'Bill' },
     relationships: {
       posts: { data: [{ type: 'posts', id: '1' }] }
     }
   });
-  let commenter = this.container.lookupFactory('model:commenters').create({
+  let commenter = this.container.lookupFactory('model:commenter').create({
     id: '3', attributes: { name: 'Virgil Erp' },
     relationships: {
       comments: { data: [{ type: 'comments', id: '4' }] }
     }
   });
-  let comment = this.container.lookupFactory('model:comments').create({
+  let comment = this.container.lookupFactory('model:comment').create({
     id: '4', attributes: { body: 'Wyatt become a deputy too.' },
     relationships: {
       commenter: { data: { type: 'commenter', id: '3' } },
@@ -227,7 +227,7 @@ test('#removeRelationship', function(assert) {
 });
 
 test('#addRelationships', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.addRelationships('comments', ['4', '5']);
@@ -243,7 +243,7 @@ test('#addRelationships', function(assert) {
 });
 
 test('#removeRelationships', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: { data: { type: 'authors', id: '2' } },
@@ -260,7 +260,7 @@ test('#removeRelationships', function(assert) {
 
 test('#updateRelationship', function(assert) {
   let serviceOp = this.sandbox.spy();
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: { data: { type: 'authors', id: '2' } },
@@ -301,7 +301,7 @@ test('#updateRelationship', function(assert) {
 
 test('#isNew resource uses relations without proxied content', function(assert) {
   let serviceOp = this.sandbox.spy();
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     isNew: true,
     // mock service
@@ -327,7 +327,7 @@ test('#isNew resource uses relations without proxied content', function(assert) 
 QUnit.skip('#initEvents', function(assert) {
   const proto = Resource.PrototypeMixin.mixins[1].properties;
   window.sinon.stub(proto, 'initEvents', function () { return; });
-  let Factory = this.container.lookupFactory('model:posts');
+  let Factory = this.container.lookupFactory('model:post');
   Factory.create({ attributes: { id: '1', title: 'Wyatt Earp', excerpt: 'Was a gambler.'} });
   assert.ok(proto.initEvents.calledOnce, 'initEvents called');
 });

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -37,7 +37,7 @@ test('#serialize calls serializeResource', function(assert) {
 
 test('#serializeResource with only attributes data', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:authors').create({
+  let resource = this.container.lookupFactory('model:author').create({
     attributes: authorMock.data.attributes
   });
   let data = serializer.serializeResource(resource);
@@ -54,7 +54,7 @@ test('#serializeResource with only attributes data', function(assert) {
 
 test('#serializeResource with attributes and relationship', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:posts').create({
+  let resource = this.container.lookupFactory('model:post').create({
     attributes: postMock.data.attributes
   });
   resource.addRelationship('author', '1');
@@ -75,7 +75,7 @@ test('#serializeResource with attributes and relationship', function(assert) {
 
 test('#serializeChanged', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let changedTitle = postMock.data.attributes.title + ' changed';
   resource.set('title', changedTitle);
   let serialized = serializer.serializeChanged(resource);
@@ -89,7 +89,7 @@ test('#serializeChanged', function(assert) {
 
 test('when #serializedChanged has nothing to return', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:posts').create(postMock.data);
+  let resource = this.container.lookupFactory('model:post').create(postMock.data);
   let serialized = serializer.serializeChanged(resource);
   assert.equal(serialized, null, 'null is returned when there are no changed attributes');
 });

--- a/tests/unit/utils/has-many-test.js
+++ b/tests/unit/utils/has-many-test.js
@@ -32,7 +32,7 @@ moduleFor('model:resource', 'Unit | Utility | hasMany', {
 });
 
 test('hasMany() helper sets up a promise proxy to a related resource', function(assert) {
-  let author = this.container.lookupFactory('model:authors').create({
+  let author = this.container.lookupFactory('model:author').create({
     id: '1', attributes: { name: 'pixelhandler' },
     relationships: {
       posts: {
@@ -43,7 +43,7 @@ test('hasMany() helper sets up a promise proxy to a related resource', function(
       }
     }
   });
-  this.container.lookupFactory('model:posts').create({
+  this.container.lookupFactory('model:post').create({
     id: '2', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -32,7 +32,7 @@ moduleFor('model:resource', 'Unit | Utility | hasOne', {
 });
 
 test('hasOne() helper sets up a promise proxy to a related resource', function(assert) {
-  let post = this.container.lookupFactory('model:posts').create({
+  let post = this.container.lookupFactory('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {
@@ -44,7 +44,7 @@ test('hasOne() helper sets up a promise proxy to a related resource', function(a
       },
     }
   });
-  this.container.lookupFactory('model:authors').create({
+  this.container.lookupFactory('model:author').create({
     id: '2', attributes: { name: 'Bill' },
     relationships: {
       posts: {


### PR DESCRIPTION
- Fix factory lookups to use singular naming for model factory
- Remove injections from initializer blueprint, standard registry naming is fine
  - service still uses plural name (common naming for an api endpoint anyway)