### PR TITLE
[Breaking] Remove Adapter#initEvents use #updateResource explicitly

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -316,15 +316,5 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
     @method cacheRemove
     @param {Resource} resource
   */
-  cacheRemove(/*resource*/) {},
-
-  /**
-    Initialize events to communicate on the resource instances' service reference.
-    Listens for resource objects trigging `attributeChanged` events
-
-    @method initEvents
-  */
-  initEvents: Ember.on('init', function () {
-    this.on('attributeChanged', this, this.updateResource);
-  })
+  cacheRemove(/*resource*/) {}
 });

--- a/tests/dummy/app/components/form-post.js
+++ b/tests/dummy/app/components/form-post.js
@@ -14,6 +14,10 @@ export default Ember.Component.extend({
   focusOut() {
     if (!this.get('isNew')) {
       this.get('resource').applyChanges();
+      this.set('isEditing', false);
+      this.get('on-edit')(this.get('post')).finally(function() {
+        this.set('isEditing', true);
+      }.bind(this));
     }
   },
 

--- a/tests/dummy/app/controllers/admin/edit.js
+++ b/tests/dummy/app/controllers/admin/edit.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    update(model) {
+      return this.store.updateResource('posts', model).catch(function(err) {
+        Ember.Logger.error(err);
+        model.rollback();
+      });
+    }
+  }
+});

--- a/tests/dummy/app/templates/admin/edit.hbs
+++ b/tests/dummy/app/templates/admin/edit.hbs
@@ -1,4 +1,4 @@
 <p>
   <strong>Edit a Blog Post</strong>
 </p>
-{{form-post post=model isNew=model.isNew}}
+{{form-post post=model isNew=model.isNew on-edit=(action "update")}}

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -6,7 +6,7 @@ import { setup, teardown } from 'dummy/tests/helpers/resources';
 import postMock from 'fixtures/api/posts/1';
 import postsMock from 'fixtures/api/posts';
 
-let sandbox, skip = QUnit.skip;
+let sandbox;
 
 function RSVPonerror(error) {
   throw new Error(error);
@@ -503,12 +503,4 @@ test('re-opening AuthorizationMixin can customize the settings for Authorization
     })
   });
   assert.equal(adapter.get('authorizationCredential'), 'Bearer SecretToken');
-});
-
-// This may only intermittently pass
-skip('#initEvents', function(assert) {
-  const proto = Adapter.PrototypeMixin.mixins[2].properties;
-  sandbox.stub(proto, 'initEvents', function () { return; });
-  this.subject();
-  assert.ok(proto.initEvents.calledOnce, 'initEvents called');
 });


### PR DESCRIPTION
The more common use case is to just call the updateResource method vs. auto-update

- No more magic calls to the adapters' `updateResource` method via `attributeChanged` events
- If developers want to use the events they can define the behavior based on the `attributeChanged` event
- Added example behavior to dummy app for updateResource and rollback on fail