### PR TITLE
Add Resource#didResolveProxyRelation method to maintain data linkage

### DIFF
--- a/addon/utils/has-many.js
+++ b/addon/utils/has-many.js
@@ -46,11 +46,12 @@ export default function hasMany(relation) {
     relation = relation.resource;
   }
   assertDasherizedHasManyRelation(relation);
-  let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
+  let kind = 'hasMany';
+  let util = RelatedProxyUtil.create({'relationship': relation, 'type': type, kind: kind});
   let path = linksPath(relation);
   return Ember.computed(path, function () {
-    return util.createProxy(this, 'many');
-  }).meta({relation: relation, type: type, kind: 'hasMany'});
+    return util.createProxy(this, kind);
+  }).meta({relation: relation, type: type, kind: kind});
 }
 
 function assertResourceAndTypeProps(relation) {

--- a/addon/utils/has-one.js
+++ b/addon/utils/has-one.js
@@ -45,11 +45,12 @@ export default function hasOne(relation) {
     relation = relation.resource;
   }
   assertDasherizedHasOneRelation(type);
-  let util = RelatedProxyUtil.create({'relationship': relation, 'type': type});
+  let kind = 'hasOne';
+  let util = RelatedProxyUtil.create({relationship: relation, type: type, kind: kind});
   let path = linksPath(relation);
   return Ember.computed(path, function () {
-    return util.createProxy(this, 'one');
-  }).meta({relation: relation, type: type, kind: 'hasOne'});
+    return util.createProxy(this, kind);
+  }).meta({relation: relation, type: type, kind: kind});
 }
 
 function assertResourceAndTypeProps(relation) {

--- a/tests/unit/utils/has-many-test.js
+++ b/tests/unit/utils/has-many-test.js
@@ -7,8 +7,8 @@ let mockServices;
 const mockService = function () {
   let sandbox = this.sandbox;
   return Ember.Service.extend({
-    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(null); }),
-    cacheLookup: sandbox.spy(function () { return []; })
+    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(Ember.A([Ember.Object.create({id: 1})])); }),
+    cacheLookup: sandbox.spy(function () { return Ember.A([]); })
   });
 };
 let entities = ['post', 'author'];

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -7,8 +7,8 @@ let mockServices;
 const mockService = function () {
   let sandbox = this.sandbox;
   return Ember.Service.extend({
-    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(null); }),
-    cacheLookup: sandbox.spy(function () { return []; })
+    findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(Ember.Object.create({id: 1})); }),
+    cacheLookup: sandbox.spy(function () { return Ember.A([]); })
   });
 };
 let entities = ['post', 'author'];


### PR DESCRIPTION
Keeps relationship[relation].data updated on the resource instance following resolution of promise proxy for relations.