### PR TITLE
Use owner API instead of this.container (deprecated in 2.3)

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -115,7 +115,8 @@ export default Ember.Object.extend(FetchMixin, Ember.Evented, {
       type = resource.type;
     }
     // use resource's service if in container, otherwise use this service to fetch
-    let service = this.container.lookup('service:' + pluralize(type)) || this;
+    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+    let service = owner.lookup('service:' + pluralize(type)) || this;
     url = this.fetchUrl(url);
     return service.fetch(url, { method: 'GET' });
   },

--- a/addon/initializers/model-setup.js
+++ b/addon/initializers/model-setup.js
@@ -1,0 +1,21 @@
+/**
+  @module ember-jsonapi-resources
+  @submodule initializers
+**/
+
+/**
+  Initializer for the model factories, registers option to not initialize
+
+  @method initialize
+  @for Resource
+*/
+export function initialize(application) {
+  if (typeof application.registerOptionsForType === 'function') {
+    application.registerOptionsForType('model', { instantiate: false });
+  }
+}
+
+export default {
+  name: 'model-setup',
+  initialize
+};

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -155,7 +155,8 @@ export default Ember.Object.extend({
     if (!related) { return; }
     let resource, service;
     for (let i = 0; i < related.length; i++) {
-      service = this.container.lookup('service:' + pluralize(related[i].type));
+      let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+      service = owner.lookup('service:' + pluralize(related[i].type));
       if (service && service.cache && service.cache.data) {
         resource = service.serializer.deserializeResource(related[i]);
         service.cacheResource({ meta: resp.meta, data: resource, headers: resp.headers});
@@ -238,7 +239,8 @@ export default Ember.Object.extend({
     @return {Function} factory for creating resource instances
   */
   _lookupFactory(type) {
-    return this.container.lookupFactory('model:' + singularize(type));
+    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+    return owner.lookup('model:' + singularize(type));
   }
 });
 

--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -81,7 +81,8 @@ const RelatedProxyUtil = Ember.Object.extend({
     let relation = this.get('relationship');
     let type = this.get('type');
     let url = this.proxyUrl(resource, relation);
-    let service = resource.container.lookup('service:' + pluralize(type));
+    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(resource) : resource.container;
+    let service = owner.lookup('service:' + pluralize(type));
     let promise = this.promiseFromCache(resource, relation, service);
     promise = promise || service.findRelated({'resource': relation, 'type': type}, url);
     let proxyProto = proxyFactory.extend(Ember.PromiseProxyMixin, {

--- a/app/initializers/model-setup.js
+++ b/app/initializers/model-setup.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-jsonapi-resources/initializers/model-setup';

--- a/blueprints/jsonapi-initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/jsonapi-initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -21,15 +21,12 @@ module('<%= friendlyTestName %>', {
   }
 });
 
-test('it registers <%= resource %> factories: model, service, adapter, serializer; injects: service, serializer', function(assert) {
+test('it registers <%= resource %> factory: model, injects into: service, serializer', function(assert) {
   <%= classifiedModuleName %>Initializer.initialize(registry, application);
 
   let registered = Ember.A(factories.mapBy('name'));
-  assert.ok(registered.contains('model:<%= resource %>'), 'model:<%= resource %> registered');
-  assert.ok(registered.contains('service:<%= resource %>'), 'service:<%= resource %> registered');
-  assert.ok(registered.contains('adapter:<%= resource %>'), 'adapter:<%= resource %> registered');
-  assert.ok(registered.contains('serializer:<%= resource %>'), 'serializer:<%= resource %> registered');
-  let msg = 'briefs injected into service:store';
+  assert.ok(registered.contains('model:<%= entity %>'), 'model:<%= entity %> registered');
+  let msg = '<%= resource %> injected into service:store';
   assert.equal(injections.findBy('factory', 'service:store').property, '<%= resource %>', msg);
   msg = 'serializer injected into service:<%= resource %>';
   assert.equal(injections.findBy('factory', 'service:<%= resource %>').property, 'serializer', msg);

--- a/blueprints/jsonapi-initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/jsonapi-initializer/files/__root__/initializers/__name__.js
@@ -1,7 +1,9 @@
+import Resource from '<%= modelPath %>';
+
 export function initialize() {
   // see http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
   let application = arguments[1] || arguments[0];
-
+  application.register('model:<%= entity %>', Resource, { instantiate: false, singleton: false });
   application.inject('service:store', '<%= resource %>', 'service:<%= resource %>');
   application.inject('service:<%= resource %>', 'serializer', 'serializer:<%= entity %>');
 }

--- a/blueprints/jsonapi-model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/jsonapi-model-test/files/tests/unit/__path__/__test__.js
@@ -1,22 +1,21 @@
 import { moduleFor, test } from 'ember-qunit';
 import Model from '<%= modelPath %>';
+import Ember from 'ember';
 
 moduleFor('model:<%= dasherizedModuleName %>', '<%= friendlyDescription %>', {
   // Specify the other units that are required for this test.
 <%= typeof needs !== 'undefined' ? needs : '' %>
   beforeEach() {
-    const opts = { instantiate: false, singleton: false };
-    Model.prototype.container = this.container;
-    // Use a non-standard name, i.e. pluralized instead of singular
-    this.registry.register('model:<%= resource %>', Model, opts);
+    let opts = { instantiate: false, singleton: false };
+    this.registry.register('model:<%= entity %>', Model, opts);
   },
   afterEach() {
-    delete Model.prototype.container;
-    this.registry.unregister('model:<%= resource %>');
+    this.registry.unregister('model:<%= entity %>');
   }
 });
 
 test('<%= resource %> has "type" property set to: <%= resource %>', function(assert) {
-  var model = this.container.lookupFactory('model:<%= resource %>').create();
+  let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+  let model = owner.lookup('model:<%= entity %>').create();
   assert.equal(model.get('type'), '<%= resource %>', 'resource has expected type');
 });

--- a/blueprints/jsonapi-serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/jsonapi-serializer-test/files/tests/unit/__path__/__test__.js
@@ -1,11 +1,16 @@
 import { moduleFor, test } from 'ember-qunit';
 import Resource from '<%= modelPath %>';
+import Ember from 'ember';
 
 moduleFor('serializer:<%= entity %>', '<%= friendlyTestDescription %>', {
   beforeEach() {
-    Resource.prototype.container = this.container;
+    if (typeof Ember.setOwner === 'function') {
+      Ember.setOwner(Resource.prototype, Ember.getOwner(this));
+    } else {
+      Resource.prototype.container = this.container;
+    }
     let opts = { instantiate: false, singleton: false };
-    this.registry.register('model:<%= resource %>', Resource, opts);
+    this.registry.register('model:<%= entity %>', Resource, opts);
   },
   afterEach() {
     delete Resource.prototype.container;
@@ -14,7 +19,8 @@ moduleFor('serializer:<%= entity %>', '<%= friendlyTestDescription %>', {
 
 // Replace this with your real tests.
 test('it serializes resources', function(assert) {
-  let resource = this.container.lookupFactory('model:<%= resource %>').create();
+  let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+  let resource = owner.lookup('model:<%= entity %>').create();
   let serializer = this.subject();
   var serializedResource = serializer.serialize(resource);
   assert.equal(serializedResource.data.type, '<%= resource %>', 'serializes a <%= entity %> resource');

--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,8 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "1.11.3",
-    "loader.js": "ember-cli/loader.js#3.4.0",
+    "jquery": "~1.11.3",
+    "loader.js": "^3.5.0",
     "fetch": "~0.10.1",
     "es6-promise": "~3.0.2",
     "blanket": "~1.1.5"

--- a/tests/acceptance/polymorphic-test.js
+++ b/tests/acceptance/polymorphic-test.js
@@ -20,7 +20,7 @@ module('Acceptance | polymorphic', {
   }
 });
 
-test('visiting /pictures', function(assert) {
+test('visiting /pictures list', function(assert) {
   assert.expect(6);
   setupFetchResonses(this.sandbox);
 

--- a/tests/dummy/app/initializers/author.js
+++ b/tests/dummy/app/initializers/author.js
@@ -1,6 +1,8 @@
+import Author from '../models/author';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:author', Author, { instantiate: false, singleton: false });
   application.inject('service:store', 'authors', 'service:authors');
   application.inject('service:authors', 'serializer', 'serializer:author');
 }

--- a/tests/dummy/app/initializers/comment.js
+++ b/tests/dummy/app/initializers/comment.js
@@ -1,6 +1,8 @@
+import Comment from '../models/comment';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:comment', Comment, { instantiate: false, singleton: false });
   application.inject('service:store', 'comments', 'service:comments');
   application.inject('service:comments', 'serializer', 'serializer:comment');
 }

--- a/tests/dummy/app/initializers/commenter.js
+++ b/tests/dummy/app/initializers/commenter.js
@@ -1,6 +1,8 @@
+import Commenter from '../models/commenter';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:commenter', Commenter, { instantiate: false, singleton: false });
   application.inject('service:store', 'commenters', 'service:commenters');
   application.inject('service:commenters', 'serializer', 'serializer:commenter');
 }

--- a/tests/dummy/app/initializers/employee.js
+++ b/tests/dummy/app/initializers/employee.js
@@ -1,6 +1,8 @@
+import Employee from '../models/employee';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:employee', Employee, { instantiate: false, singleton: false });
   application.inject('service:store', 'employees', 'service:employees');
   application.inject('service:employees', 'serializer', 'serializer:employee');
 }

--- a/tests/dummy/app/initializers/imageable.js
+++ b/tests/dummy/app/initializers/imageable.js
@@ -1,6 +1,5 @@
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
   application.inject('service:store', 'imageables', 'service:imageables');
   application.inject('service:imageables', 'serializer', 'serializer:imageable');
 }

--- a/tests/dummy/app/initializers/picture.js
+++ b/tests/dummy/app/initializers/picture.js
@@ -1,6 +1,8 @@
+import Picture from '../models/picture';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:picture', Picture, { instantiate: false, singleton: false });
   application.inject('service:store', 'pictures', 'service:pictures');
   application.inject('service:pictures', 'serializer', 'serializer:picture');
 }

--- a/tests/dummy/app/initializers/post.js
+++ b/tests/dummy/app/initializers/post.js
@@ -1,6 +1,8 @@
+import Post from '../models/post';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:post', Post, { instantiate: false, singleton: false });
   application.inject('service:store', 'posts', 'service:posts');
   application.inject('service:posts', 'serializer', 'serializer:post');
 }

--- a/tests/dummy/app/initializers/product.js
+++ b/tests/dummy/app/initializers/product.js
@@ -1,6 +1,8 @@
+import Product from '../models/product';
+
 export function initialize() {
   let application = arguments[1] || arguments[0];
-
+  application.register('model:product', Product, { instantiate: false, singleton: false });
   application.inject('service:store', 'products', 'service:products');
   application.inject('service:products', 'serializer', 'serializer:product');
 }

--- a/tests/dummy/app/routes/admin/create.js
+++ b/tests/dummy/app/routes/admin/create.js
@@ -8,7 +8,8 @@ export default Ember.Route.extend({
   },
 
   model() {
-    return this.container.lookup('model:post').create({
+    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+    return owner.lookup('model:post').create({
       isNew: true,
       attributes: { date: new Date() }
     });

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -93,11 +93,11 @@ test('#findQuery calls #fetch url including a query', function(assert) {
 
 test('#findRelated', function(assert) {
   this.registry.register('service:authors', Adapter.extend({type: 'authors', url: '/authors'}));
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let url = resource.get( ['relationships', 'author', 'links', 'related'].join('.') );
   const adapter = this.subject({type: 'posts', url: '/posts'});
   let service = this.container.lookup('service:authors');
-  let related = this.container.lookupFactory('model:author').create(authorMock.data);
+  let related = this.container.lookup('model:author').create(authorMock.data);
   sandbox.stub(service, 'fetch', function () { return Ember.RSVP.Promise.resolve(related); });
   let promise = adapter.findRelated('author', url);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -113,7 +113,7 @@ test('#findRelated can be called with optional type for the resource', function 
   PersonAdapter.reopenClass({ isServiceFactory: true });
   this.registry.register('service:people', PersonAdapter.extend());
   let service = this.container.lookup('service:people');
-  let supervisor = this.container.lookupFactory('model:employee').create({
+  let supervisor = this.container.lookup('model:employee').create({
     type: 'supervisors',
     id: 1000000,
     name: 'The Boss',
@@ -128,7 +128,7 @@ test('#findRelated can be called with optional type for the resource', function 
   let stub = sandbox.stub(service, 'findRelated', function () {
     return Ember.RSVP.Promise.resolve(supervisor);
   });
-  let resource = this.container.lookupFactory('model:employee').create({
+  let resource = this.container.lookup('model:employee').create({
     type: 'employees',
     id: 1000001,
     name: 'The Special',
@@ -154,7 +154,7 @@ test('#createResource', function(assert) {
   assert.expect(6);
   let done = assert.async();
   const adapter = this.subject({type: 'posts', url: '/posts'});
-  let postFactory = this.container.lookupFactory('model:post');
+  let postFactory = this.container.lookup('model:post');
   let data = JSON.parse(JSON.stringify(postMock.data));
   delete data.id;
   let newResource = postFactory.create(data);
@@ -187,7 +187,7 @@ test('#updateResource', function(assert) {
   };
   adapter.serializer = { serializeChanged: function () { return payload; } };
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   assert.ok(adapter.fetch.calledOnce, '#fetch method called');
@@ -200,7 +200,7 @@ test('#updateResource returns null when serializer returns null (nothing changed
   const adapter = this.subject({type: 'posts', url: '/posts'});
   adapter.serializer = { serializeChanged: function () { return null; } };
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.equal(promise, null, 'null returned instead of promise');
   assert.ok(!adapter.fetch.calledOnce, '#fetch method NOT called');
@@ -209,7 +209,7 @@ test('#updateResource returns null when serializer returns null (nothing changed
 test('#patchRelationship (to-many)', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   resource.addRelationship('comments', '1');
   let promise = adapter.patchRelationship(resource, 'comments');
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -222,7 +222,7 @@ test('#patchRelationship (to-many)', function(assert) {
 test('#patchRelationship (to-one)', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   resource.addRelationship('author', '1');
   let promise = adapter.patchRelationship(resource, 'author');
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -244,7 +244,7 @@ test('#deleteResource can be called with a string as the id for the resource', f
 test('#deleteResource can be called with a resource having a self link, and calls resource#destroy', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   sandbox.stub(resource, 'destroy', function () {});
   let promise = adapter.deleteResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -257,7 +257,7 @@ test('#deleteResource can be called with a resource having a self link, and call
 test('when called with resource argument, #deleteResource calls #cacheRemove', function(assert) {
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return Ember.RSVP.Promise.resolve(null); });
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   sandbox.stub(adapter, 'cacheRemove', function () {});
   Ember.run(function() {
     adapter.deleteResource(resource);
@@ -360,7 +360,7 @@ test('#cacheUpdate called after #updateResource success', function(assert) {
     serializeChanged: function () { return payload; },
     transformAttributes: function(json) { return json; }
   };
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(function() {
@@ -418,7 +418,7 @@ test('#fetch handles 4xx (Client Error) response status', function(assert) {
     return Ember.RSVP.Promise.resolve({
       "status": 404,
       "text": function() {
-        return Ember.RSVP.Promise.resolve("{ errors: [ { status: 404 } ] }");
+        return Ember.RSVP.Promise.resolve('{ "errors": [ { "status": 404 } ] }');
       }
     });
   });

--- a/tests/unit/initializers/model-setup-test.js
+++ b/tests/unit/initializers/model-setup-test.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import initializer from '../../../initializers/model-setup';
+import { module, test } from 'qunit';
+
+let application, registeredTypeOptions;
+
+module('Unit | Initializer | model-setup', {
+  beforeEach() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      application.deferReadiness();
+      stub(application);
+    });
+  },
+  afterEach() {
+    application = null;
+    registeredTypeOptions = null;
+  }
+});
+
+test('registers intantiate:false option for model factories', function(assert) {
+  initializer.initialize(application);
+  let option = registeredTypeOptions.findBy('name', 'model');
+  assert.equal(option.name, 'model', 'option for model registered');
+  assert.equal(option.options.instantiate, false, 'option set to "instantiate:false"');
+});
+
+function stub(app) {
+  registeredTypeOptions = Ember.A([]);
+  app.registerOptionsForType = function(name, options) {
+    registeredTypeOptions.pushObject({name: name, options: options});
+  };
+}

--- a/tests/unit/initializers/store-test.js
+++ b/tests/unit/initializers/store-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { initialize } from '../../../initializers/store';
 import { module, test } from 'qunit';
 
-var registry, application, factories, injections;
+let registry, application, factories, injections;
 
 module('Unit | Initializer | store', {
   beforeEach: function() {
@@ -10,8 +10,8 @@ module('Unit | Initializer | store', {
       application = Ember.Application.create();
       registry = application.registry;
       application.deferReadiness();
+      application = stub(application);
     });
-    application = stub(application);
   },
   afterEach: function() {
     factories = null;

--- a/tests/unit/mixins/service-cache-test.js
+++ b/tests/unit/mixins/service-cache-test.js
@@ -1,18 +1,22 @@
 import Ember from 'ember';
 import ServiceCacheMixin from '../../../mixins/service-cache';
-import { module, test } from 'qunit';
-import { Post } from 'dummy/tests/helpers/resources';
+import { moduleFor, test } from 'ember-qunit';
+import { setup, teardown } from 'dummy/tests/helpers/resources';
 
-let sandbox, subject;
+let sandbox, subject, Post;
 
-module('Unit | Mixin | service cache', {
+moduleFor('mixin:service-cache', 'Unit | Mixin | service-cache', {
   beforeEach() {
     sandbox = window.sinon.sandbox.create();
     let ServiceCacheObject = Ember.Object.extend(ServiceCacheMixin);
     subject = ServiceCacheObject.create();
+    setup.call(this);
+    Post = this.container.lookup('model:post');
   },
   afterEach() {
     sandbox.restore();
+    teardown.call(this);
+    Post = null;
   }
 });
 

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,5 +1,4 @@
 import { moduleFor, test } from 'ember-qunit';
-import Ember from 'ember';
 import { setup, teardown } from 'dummy/tests/helpers/resources';
 
 import authorMock from 'fixtures/api/authors/1';
@@ -37,7 +36,7 @@ test('#serialize calls serializeResource', function(assert) {
 
 test('#serializeResource with only attributes data', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:author').create({
+  let resource = this.container.lookup('model:author').create({
     attributes: authorMock.data.attributes
   });
   let data = serializer.serializeResource(resource);
@@ -54,7 +53,7 @@ test('#serializeResource with only attributes data', function(assert) {
 
 test('#serializeResource with attributes and relationship', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:post').create({
+  let resource = this.container.lookup('model:post').create({
     attributes: postMock.data.attributes
   });
   resource.addRelationship('author', '1');
@@ -75,13 +74,13 @@ test('#serializeResource with attributes and relationship', function(assert) {
 
 test('#serializeChanged', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let changedTitle = postMock.data.attributes.title + ' changed';
   resource.set('title', changedTitle);
   let serialized = serializer.serializeChanged(resource);
-  let actual = Ember.keys(serialized.data.attributes).length;
+  let actual = Object.keys(serialized.data.attributes).length;
   assert.equal(actual, 1, 'only 1 attribute is serialized.');
-  actual = Ember.keys(serialized.data.attributes)[0];
+  actual = Object.keys(serialized.data.attributes)[0];
   assert.equal(actual, 'title', 'only the changed title is serialized.');
   actual = serialized.data.attributes.title;
   assert.equal(actual, changedTitle, 'title is serialized with changed value');
@@ -89,7 +88,7 @@ test('#serializeChanged', function(assert) {
 
 test('when #serializedChanged has nothing to return', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookupFactory('model:post').create(postMock.data);
+  let resource = this.container.lookup('model:post').create(postMock.data);
   let serialized = serializer.serializeChanged(resource);
   assert.equal(serialized, null, 'null is returned when there are no changed attributes');
 });

--- a/tests/unit/utils/attr-test.js
+++ b/tests/unit/utils/attr-test.js
@@ -45,75 +45,75 @@ test('using attr("string") throws an assertion error when getting with another t
 
 test('attr("boolean" setting a boolean)', function(assert) {
   let Person = Resource.extend({
-    isCowboy: attr('boolean')
+    "is-cowboy": attr('boolean')
   });
   let person = Person.create();
-  person.set('isCowboy', true);
-  assert.equal(person.get('isCowboy'), true, 'person set with a boolean attribute');
+  person.set("is-cowboy", true);
+  assert.equal(person.get("is-cowboy"), true, 'person set with a boolean attribute');
 });
 
 test('attr("boolean" getting a boolean)', function(assert) {
   let Person = Resource.extend({
-    isCowboy: attr('boolean')
+    "is-cowboy": attr('boolean')
   });
-  let person = Person.create({ attributes: {'isCowboy': true} });
-  assert.equal(person.get('isCowboy'), true, 'person.get("isCowboy") is a boolean attribute');
+  let person = Person.create({ attributes: {"is-cowboy": true} });
+  assert.equal(person.get("is-cowboy"), true, 'person.get("is-cowboy") is a boolean attribute');
 });
 
 test('using attr("boolean") throws an assertion error when setting with another type', function(assert) {
   let Person = Resource.extend({
-    isCowboy: attr('boolean')
+    "is-cowboy": attr('boolean')
   });
   let person = Person.create();
   assert.throws(function() {
-    person.set('isCowboy', 'yep');
-  }, 'Setting isCowboy to `"yep"` throws an assertion error');
+    person.set("is-cowboy", 'yep');
+  }, 'Setting "is-cowboy" to `"yep"` throws an assertion error');
 });
 
 test('using attr("boolean") throws an assertion error when getting with another type', function(assert) {
   let Person = Resource.extend({
-    isCowboy: attr('boolean')
+    "is-cowboy": attr('boolean')
   });
-  let person = Person.create({ attributes: {'isCowboy': 'yep'} });
+  let person = Person.create({ attributes: {"is-cowboy": 'yep'} });
   assert.throws(function() {
-    person.get('isCowboy');
-  }, 'Getting isCowboy already set with a `"yep"` throws an assertion error');
+    person.get("is-cowboy");
+  }, 'Getting "is-cowboy" already set with a `"yep"` throws an assertion error');
 });
 
 test('attr("number") setting a number', function(assert) {
   let Person = Resource.extend({
-    birthYear: attr('number')
+    "birth-year": attr('number')
   });
   let person = Person.create();
-  person.set('birthYear', 1848);
-  assert.equal(person.get('birthYear'), 1848, 'person set with a number attribute');
+  person.set('birth-year', 1848);
+  assert.equal(person.get('birth-year'), 1848, 'person set with a number attribute');
 });
 
 test('attr("number") getting a number', function(assert) {
   let Person = Resource.extend({
-    birthYear: attr('number')
+    "birth-year": attr('number')
   });
-  let person = Person.create({ attributes: {'birthYear': 1848} });
-  assert.equal(person.get('birthYear'), 1848, 'person.get("birthYear") is a number');
+  let person = Person.create({ attributes: {'birth-year': 1848} });
+  assert.equal(person.get('birth-year'), 1848, 'person.get("birthYear") is a number');
 });
 
 test('using attr("number") throws an assertion error when setting with another type', function(assert) {
   let Person = Resource.extend({
-    birthYear: attr('number')
+    "birth-year": attr('number')
   });
   let person = Person.create();
   assert.throws(function() {
-    person.set('birthYear', '1848');
+    person.set('birth-year', '1848');
   }, 'Setting birthYear to `"1848"` throws an assertion error');
 });
 
 test('using attr("number") throws an assertion error when getting with another type', function(assert) {
   let Person = Resource.extend({
-    birthYear: attr('number')
+    "birth-year": attr('number')
   });
-  let person = Person.create({ attributes: {'birthYear': '1848'} });
+  let person = Person.create({ attributes: {'birth-year': '1848'} });
   assert.throws(function() {
-    person.get('birthYear');
+    person.get('birth-year');
   }, 'Getting birthYear already set to `"1848"` throws an assertion error');
 });
 

--- a/tests/unit/utils/has-many-test.js
+++ b/tests/unit/utils/has-many-test.js
@@ -32,7 +32,7 @@ moduleFor('model:resource', 'Unit | Utility | hasMany', {
 });
 
 test('hasMany() helper sets up a promise proxy to a related resource', function(assert) {
-  let author = this.container.lookupFactory('model:author').create({
+  let author = this.container.lookup('model:author').create({
     id: '1', attributes: { name: 'pixelhandler' },
     relationships: {
       posts: {
@@ -43,7 +43,7 @@ test('hasMany() helper sets up a promise proxy to a related resource', function(
       }
     }
   });
-  this.container.lookupFactory('model:post').create({
+  this.container.lookup('model:post').create({
     id: '2', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -32,7 +32,7 @@ moduleFor('model:resource', 'Unit | Utility | hasOne', {
 });
 
 test('hasOne() helper sets up a promise proxy to a related resource', function(assert) {
-  let post = this.container.lookupFactory('model:post').create({
+  let post = this.container.lookup('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {
@@ -44,7 +44,7 @@ test('hasOne() helper sets up a promise proxy to a related resource', function(a
       },
     }
   });
-  this.container.lookupFactory('model:author').create({
+  this.container.lookup('model:author').create({
     id: '2', attributes: { name: 'Bill' },
     relationships: {
       posts: {


### PR DESCRIPTION
- Support this.owner as this.container in tests
- Clean up test with use of container (support new owner api)
- Fixup Resource test helper, no need to set container
- Register models with options, for backwards compatibility