### PR TITLE
Add blueprints for transforms and util/dictionaries

### DIFF
--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -23,7 +23,11 @@ module.exports = {
           return path.join(options.podPath, moduleName);
         }
         var blueprintName = options.originBlueprintName.replace('jsonapi-', '');
-        return inflector.pluralize(blueprintName);
+        if (blueprintName.match(/dictionary/) !== null) {
+          return 'utils/dictionaries';
+        } else {
+          return inflector.pluralize(blueprintName);
+        }
       },
       __root__: function(options) {
         if (options.inRepoAddon) {
@@ -38,14 +42,16 @@ module.exports = {
     var addonName      = stringUtil.dasherize(addonRawName);
     var blueprintName  = options.originBlueprintName.replace('jsonapi-', '');
     var fileName       = stringUtil.dasherize(options.entity.name);
-    var pathName       = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
+    var modulePath     = [addonName, inflector.pluralize(blueprintName), fileName].join('/');
 
     if (options.pod) {
-      pathName = [addonName, fileName, blueprintName].join('/');
+      modulePath = [addonName, fileName, blueprintName].join('/');
     }
-
+    if (blueprintName.match(/dictionary/) !== null) {
+      modulePath = [addonName, 'utils/dictionaries', fileName].join('/');
+    }
     return {
-      modulePath: pathName
+      modulePath: modulePath
     };
   }
 };

--- a/blueprints/jsonapi-dictionary-test/files/tests/unit/utils/dictionaries/__name__-test.js
+++ b/blueprints/jsonapi-dictionary-test/files/tests/unit/utils/dictionaries/__name__-test.js
@@ -1,0 +1,22 @@
+import <%= camelizedModuleName %> from '../../../../utils/dictionaries/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>');
+
+// Replace this with your real tests.
+test('<%= camelizedModuleName %> dictionary exists', function(assert) {
+  assert.ok(<%= camelizedModuleName %>, '<%= camelizedModuleName %> ok');
+
+  let dictionary = {
+<%= pairs %>
+  };
+  let keys = Object.keys(dictionary);
+  let values = keys.map(function(key) { return dictionary[key]; });
+
+  for (let i = 0; i < keys.length; i++) {
+    let key = keys[i];
+    let value = values[i];
+    assert.ok(!!<%= camelizedModuleName %>[key], `${key} is a key`);
+    assert.equal(<%= camelizedModuleName %>[key], value, `<%= camelizedModuleName %>[${key}] is ${value}`);
+  }
+});

--- a/blueprints/jsonapi-dictionary-test/index.js
+++ b/blueprints/jsonapi-dictionary-test/index.js
@@ -1,0 +1,28 @@
+/*jshint node:true*/
+var EOL = require('os').EOL;
+var testInfo = require('ember-cli-test-info');
+
+module.exports = {
+  description: 'Generates a dictionary util unit test.',
+  locals: function(options) {
+    var name = options.args[1];
+    var entries = options.entity.options;
+    var key, value, entry;
+    var pairs = [];
+
+    for (key in entries) {
+      if (entries.hasOwnProperty(key)) {
+        value = entries[key];
+        pairs.push(assignment(key, value));
+      }
+    }
+    return {
+      friendlyTestName: testInfo.name('dictionary/' + options.entity.name, "Unit", "Utility"),
+      pairs: pairs.join(',' + EOL)
+    };
+  }
+};
+
+function assignment(key, value) {
+  return '    "' + key + '": "' + value + '"';
+}

--- a/blueprints/jsonapi-dictionary/files/__root__/utils/dictionaries/__name__.js
+++ b/blueprints/jsonapi-dictionary/files/__root__/utils/dictionaries/__name__.js
@@ -1,0 +1,5 @@
+const dictionary = Object.create(null);
+
+<%= pairs %>
+
+export default Object.freeze(dictionary);

--- a/blueprints/jsonapi-dictionary/index.js
+++ b/blueprints/jsonapi-dictionary/index.js
@@ -1,0 +1,47 @@
+/*jshint node:true*/
+var EOL = require('os').EOL;
+var path = require('path');
+
+module.exports = {
+  description: 'Generates an dictionary util, use with ember-jsonapi-resources transfrom objects.',
+
+  anonymousOptions: [
+    'name',
+    'key:value'
+  ],
+
+  locals: function(options) {
+    var name = options.args[1];
+    var entries = options.entity.options;
+    var key, value, entry;
+    var pairs = [];
+
+    for (key in entries) {
+      if (entries.hasOwnProperty(key)) {
+        value = entries[key];
+        pairs.push(assignment(key, value));
+      }
+    }
+
+    return {
+      name: name,
+      pairs: pairs.join(EOL)
+    };
+  },
+
+  fileMapTokens: function() {
+    return {
+      __name__: function (options) {
+        var moduleName = options.dasherizedModuleName;
+        return moduleName;
+      },
+      __path__: function(options) {
+        return path.join('utils', 'dictionaries');
+      }
+    };
+  }
+};
+
+function assignment(key, value) {
+  return 'dictionary["' + key + '"] = "' + value + '";';
+}

--- a/blueprints/jsonapi-initializer/index.js
+++ b/blueprints/jsonapi-initializer/index.js
@@ -2,6 +2,7 @@
 var inflector = require('inflection');
 var stringUtil = require('ember-cli-string-utils');
 var pathUtil = require('ember-cli-path-utils');
+var path = require('path');
 
 module.exports = {
   description: 'Generates an (ember-jsonapi-resource) initializer for a service using the JSON API 1.0 spec.',

--- a/blueprints/jsonapi-transform-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/jsonapi-transform-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import <%= transformName %> from '<%= transformPath %>';
+import dictionary from '<%= dictionaryPath %>';
+
+module('<%= friendlyTestDescription %>');
+
+test('<%= transformName %>#serialize', function(assert) {
+  let value;
+  for (let key in dictionary) {
+    value = <%= transformName %>.serialize(dictionary[key]);
+    assert.equal(value, key, 'serialize("'+ dictionary[key] +'") is `' + key + '`');
+  }
+});
+
+test('<%= transformName %>#deserialize', function(assert) {
+  let value;
+  for (let key in dictionary) {
+    value = <%= transformName %>.deserialize(key);
+    assert.equal(value, dictionary[key], 'deserialize("'+ key +'") is `' + dictionary[key] +'`');
+  }
+});

--- a/blueprints/jsonapi-transform-test/index.js
+++ b/blueprints/jsonapi-transform-test/index.js
@@ -1,0 +1,35 @@
+/*jshint node:true*/
+var testInfo = require('ember-cli-test-info');
+var inflector = require('inflection');
+var stringUtil = require('ember-cli-string-utils');
+var pathUtil = require('ember-cli-path-utils');
+
+module.exports = {
+  description: 'Generates a value transform unit test for use with ember-jsonapi-resources.',
+
+  locals: function(options) {
+    var transformName = options.entity.name || options.args[1];
+    var dasherized = stringUtil.dasherize(transformName);
+    var relativePath = pathUtil.getRelativeParentPath('../../');
+    var dictionaryPath = relativePath + [ 'utils', 'dictionaries', dasherized ].join('/');
+    var transformPath = relativePath + [ 'transforms', dasherized ].join('/');
+
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, "Unit", "Transform"),
+      dictionaryPath: dictionaryPath,
+      transformPath: transformPath,
+      transformName: stringUtil.camelize(transformName)
+    };
+  },
+
+  fileMapTokens: function() {
+    return {
+      __name__: function (options) {
+        return options.dasherizedModuleName.replace('jsonapi-', '');
+      },
+      __path__: function(options) {
+        return inflector.pluralize(options.originBlueprintName.replace('jsonapi-', ''));
+      }
+    };
+  }
+};

--- a/blueprints/jsonapi-transform/files/__root__/__path__/__name__.js
+++ b/blueprints/jsonapi-transform/files/__root__/__path__/__name__.js
@@ -1,0 +1,16 @@
+import TransformMap from 'ember-jsonapi-resources/utils/transform-map';
+import dictionary from '<%= dictionaryPath %>';
+
+class <%= className %> extends TransformMap {
+
+  deserialize(serialized) {
+    return this.lookup(serialized);
+  }
+
+  serialize(deserialized) {
+    return this.lookup(deserialized, 'values');
+  }
+
+}
+
+export default new <%= className %>(dictionary);

--- a/blueprints/jsonapi-transform/index.js
+++ b/blueprints/jsonapi-transform/index.js
@@ -1,0 +1,31 @@
+/*jshint node:true*/
+var inflector = require('inflection');
+var stringUtil = require('ember-cli-string-utils');
+var pathUtil = require('ember-cli-path-utils');
+var path = require('path');
+
+module.exports = {
+  description: 'Generates an value transform for use with ember-jsonapi-resources.',
+
+  locals: function(options) {
+    var transformName = options.entity.name || options.args[1];
+    var relativePath = pathUtil.getRelativeParentPath('.');
+    var dictionaryPath = relativePath + [ 'utils', 'dictionaries', stringUtil.dasherize(transformName) ].join('/');
+
+    return {
+      dictionaryPath: dictionaryPath,
+      className: 'Transform' + stringUtil.classify(transformName) + 'Attribute'
+    };
+  },
+
+  fileMapTokens: function() {
+    return {
+      __name__: function (options) {
+        return options.dasherizedModuleName.replace('jsonapi-', '');
+      },
+      __path__: function(options) {
+        return inflector.pluralize(options.originBlueprintName.replace('jsonapi-', ''));
+      }
+    };
+  }
+};


### PR DESCRIPTION
- Add blueprint for dictionary util to use with transform objects
- Add value transforms blueprint, uses util/dictionaries

New blueprints are to support custom types, perhaps to support an enum field in your database.

See:
- https://github.com/pixelhandler/ember-jsonapi-resources/wiki/Transforms
- https://github.com/pixelhandler/ember-jsonapi-resources/wiki/Enum-Attributes