### PR TITLE
Add blueprint for transforms mixin to use with serializers

### DIFF
--- a/blueprints/addon-import/index.js
+++ b/blueprints/addon-import/index.js
@@ -14,7 +14,12 @@ module.exports = {
         if (options.pod && options.hasPathToken) {
           return blueprintName;
         }
-        var moduleName = options.dasherizedModuleName.replace('jsonapi-', '');
+        var moduleName;
+        if (blueprintName.match(/transform-mixin/) !== null) {
+          moduleName = options.dasherizedModuleName + '-transforms';
+        } else {
+          moduleName = options.dasherizedModuleName;
+        }
         return moduleName;
       },
       __path__: function(options) {
@@ -25,6 +30,8 @@ module.exports = {
         var blueprintName = options.originBlueprintName.replace('jsonapi-', '');
         if (blueprintName.match(/dictionary/) !== null) {
           return 'utils/dictionaries';
+        } else if (blueprintName.match(/transform-mixin/) !== null) {
+          return 'mixins';
         } else {
           return inflector.pluralize(blueprintName);
         }
@@ -49,6 +56,8 @@ module.exports = {
     }
     if (blueprintName.match(/dictionary/) !== null) {
       modulePath = [addonName, 'utils/dictionaries', fileName].join('/');
+    } else if (blueprintName.match(/transform-mixin/) !== null) {
+      modulePath = [addonName, 'mixins', fileName + '-transforms'].join('/');
     }
     return {
       modulePath: modulePath

--- a/blueprints/jsonapi-model-test/index.js
+++ b/blueprints/jsonapi-model-test/index.js
@@ -8,7 +8,7 @@ var pathUtil = require('ember-cli-path-utils');
 var getDependencyDepth = require('ember-cli-get-dependency-depth');
 
 module.exports = {
-  description: 'Generates a model unit test.',
+  description: 'Generates a (ember-jsonapi-resource) model unit test.',
 
   locals: function(options) {
     var resource = options.entity.name || options.args[1];

--- a/blueprints/jsonapi-serializer-test/index.js
+++ b/blueprints/jsonapi-serializer-test/index.js
@@ -8,7 +8,7 @@ var SerializerBlueprint = require('../jsonapi-serializer');
 var getDependencyDepth = require('ember-cli-get-dependency-depth');
 
 module.exports = {
-  description: 'Ember JSON API Resources: generates a serializer unit test.',
+  description: 'Generates an (ember-jsonapi-resource) serializer unit test.',
 
   locals: function(options) {
     var resource = options.entity.name || options.args[1];

--- a/blueprints/jsonapi-transform-mixin/files/__root__/mixins/__name__.js
+++ b/blueprints/jsonapi-transform-mixin/files/__root__/mixins/__name__.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+<%= imports %>
+
+export default Ember.Mixin.create({
+
+<%= methods %>
+
+});

--- a/blueprints/jsonapi-transform-mixin/index.js
+++ b/blueprints/jsonapi-transform-mixin/index.js
@@ -1,0 +1,74 @@
+/*jshint node:true*/
+var inflector = require('inflection');
+var stringUtil = require('ember-cli-string-utils');
+var EOL = require('os').EOL;
+
+module.exports = {
+  description: 'Generates an mixin for using value transforms w/ ember-jsonapi-resources serializers.',
+
+  anonymousOptions: ['name', 'attr-name'],
+
+  locals: function(options) {
+    var entity = options.args[1];
+    var attrNames = Object.keys(options.entity.options);
+    var attrName, imports = [], methods = [];
+
+    for (var i = 0; i < attrNames.length; i++) {
+      attrName = attrNames[i];
+      imports.push( makeImport(attrName) );
+      methods.push( makeTransformMethods(attrName) );
+    }
+
+    return {
+      imports: imports.join(EOL),
+      methods: methods.join(',' + EOL + EOL)
+    };
+  },
+
+  fileMapTokens: function() {
+    return {
+      __name__: function (options) {
+        return options.dasherizedModuleName + '-transforms';
+      },
+      __path__: function(options) {
+        return inflector.pluralize(options.originBlueprintName.replace('jsonapi-transform-', ''));
+      }
+    };
+  }
+};
+
+function makeImport(attrName) {
+  var transformName = makeTransformName(attrName);
+  var dasherized = stringUtil.dasherize(attrName);
+  return "import " + transformName + " from '../transforms/" + dasherized + "';";
+}
+
+function makeTransformMethods(attrName) {
+  return [ makeDeserializeMethod(attrName), makeSerializeMethod(attrName) ].join(',' + EOL + EOL);
+}
+
+function makeSerializeMethod(attrName) {
+  var camelized = stringUtil.camelize(attrName);
+  var methodName = 'serialize'+ stringUtil.classify(attrName) + 'Attribute';
+  var transformName = makeTransformName(attrName);
+  var loc = [];
+  loc.push('  ' + methodName + '(deserialized) {');
+  loc.push('    ' + 'return ' + transformName + '.serialize(deserialized);');
+  loc.push('  }');
+  return loc.join(EOL);
+}
+
+function makeDeserializeMethod(attrName) {
+  var camelized = stringUtil.camelize(attrName);
+  var methodName = 'deserialize'+ stringUtil.classify(attrName) + 'Attribute';
+  var transformName = makeTransformName(attrName);
+  var loc = [];
+  loc.push('  ' + methodName + '(serialized) {');
+  loc.push('    ' + 'return ' + transformName + '.deserialize(serialized);');
+  loc.push('  }');
+  return loc.join(EOL);
+}
+
+function makeTransformName(attrName) {
+  return stringUtil.camelize(attrName) + 'Transform';
+}


### PR DESCRIPTION
The `jsonapi-transform-mixin` generates a mixin to use with your serializer for specific attributes that you have transform objects for.

Example workflow for adding a custom transform for the status attribute of a post resource (model):

    ember g jsonapi-dictionary status active:Active pending:Pending archived:Archive
    ember g jsonapi-transform status
    ember g jsonapi-transform-mixin post status

See: https://github.com/pixelhandler/ember-jsonapi-resources/wiki/Transforms