### PR TITLE
Add code property to custom errors

### DIFF
--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -18,6 +18,7 @@ export function ServerError(message = 'Server Error', response = null) {
   this.name = 'ServerError';
   this.response = response;
   this.errors = (response) ? response.errors || null : null;
+  this.code = (response) ? response.status || null : null;
 }
 ServerError.prototype = errorProtoFactory(ServerError);
 
@@ -36,6 +37,7 @@ export function ClientError(message = 'Client Error', response = null) {
   this.name = 'ClientError';
   this.response = response;
   this.errors = (response) ? response.errors || null : null;
+  this.code = (response) ? response.status || null : null;
 }
 ClientError.prototype = errorProtoFactory(ClientError);
 
@@ -43,18 +45,19 @@ ClientError.prototype = errorProtoFactory(ClientError);
   @class FetchError
   @constructor
   @param {String} message
-  @param {Error} error
-  @param {Object} response
+  @param {Error|Object} error or response object
   @return {Error}
 */
-export function FetchError(message = 'Fetch Error', error = null, response = null) {
+export function FetchError(message = 'Fetch Error', response = null) {
   let _error = Error.prototype.constructor.call(this, message);
   _error.name = this.name = 'FetchError';
-  this.stack = (error && error.stack) ? error.stack : _error.stack;
-  this.message = (error && error.message) ? error.message : _error.message;
+  this.stack = (response && response.stack) ? response.stack : _error.stack;
+  this.message = (response && response.message) ? response.message : _error.message;
   this.name = 'FetchError';
-  this.response = response;
-  this.error = error || _error;
+  this.error = (response instanceof Error) ? response : _error;
+  this.response = (response instanceof Error) ? null : response;
+  this.errors = (this.response) ? response.errors : null;
+  this.code = (response) ? response.status || null : null;
 }
 FetchError.prototype = errorProtoFactory(FetchError);
 

--- a/tests/unit/mixins/fetch-test.js
+++ b/tests/unit/mixins/fetch-test.js
@@ -41,19 +41,20 @@ test('#useFetch default value is true', function(assert) {
 });
 
 test('#_ajax handles 5xx (Server Error)', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   const done = assert.async();
   this.server.respondWith('GET', '/posts', [500, {}, ""]);
   let promise = this.subject._ajax('/posts', { method: 'GET' }, false);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.catch(function(error) {
     assert.equal(error.name, 'ServerError', '5xx response throws a custom error');
+    assert.equal(error.code, 500, 'error code 500');
     done();
   });
 });
 
 test('#_ajax handles 4xx (Client Error)', function(assert) {
-  assert.expect(4);
+  assert.expect(5);
   const done = assert.async();
   this.server.respondWith('GET', '/posts/101', [
     404,
@@ -73,6 +74,7 @@ test('#_ajax handles 4xx (Client Error)', function(assert) {
     assert.ok(error.name, 'Client Error', '4xx response throws a custom error');
     assert.ok(Array.isArray(error.errors), '4xx error includes errors');
     assert.equal(error.errors[0].code, 404, '404 error code is in errors list');
+    assert.equal(error.code, 404, 'error code 404');
     done();
   });
 });
@@ -85,7 +87,7 @@ test('#_ajax handles 3xx error', function(assert) {
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.catch(function(error) {
     assert.equal(error.name, 'FetchError', 'unknown error response throws a custom error');
-    assert.equal(error.error.code, 302, '302 error code');
+    assert.equal(error.code, 302, '302 error code');
     done();
   });
 });


### PR DESCRIPTION
- Add HTTP status code as a property of the custom error objects.
- Change arguments for FetchError to use `response` or `error` as 2nd argument, remove 3rd argument.
- Use common error messaging/formatting methods for custom error types based on request type (fetch/xhr)