### PR TITLE
Assign relations to computed properties that use a proxy object

### DIFF
--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -56,16 +56,16 @@ const RelatedProxyUtil = Ember.Object.extend({
     @return {PromiseProxy|ObjectProxy|ArrayProxy} proxy instance, new resource uses mock relations
   */
   createProxy(resource, kind) {
-    let mockRelation, proxyFactory;
+    let proxyFactory, newContent;
     if (kind === 'hasMany') {
-      mockRelation = Ember.A([]);
       proxyFactory = Ember.ArrayProxy;
+      newContent = Ember.A([]);
     } else if (kind === 'hasOne') {
-      mockRelation = Ember.Object.create();
       proxyFactory = Ember.ObjectProxy;
+      newContent = Ember.Object.create();
     }
     if (resource.get('isNew')) {
-      return mockRelation;
+      return proxyFactory.create({ content: newContent });
     } else {
       let proxy = this.proxySetup(resource, kind, proxyFactory);
       return this.proxyResolution(resource, proxy);
@@ -124,8 +124,8 @@ const RelatedProxyUtil = Ember.Object.extend({
     @return {PromiseProxy} proxy
   */
   proxyUrl(resource, relation) {
-    const related = linksPath(relation);
-    const url = resource.get(related);
+    let related = linksPath(relation);
+    let url = resource.get(related);
     if (typeof url !== 'string') {
       throw new Error('RelatedProxyUtil#_proxyUrl expects `model.'+ related +'` property to exist.');
     }

--- a/tests/helpers/resources.js
+++ b/tests/helpers/resources.js
@@ -47,7 +47,7 @@ export const Supervisor = Employee.extend({
 });
 
 export function setup() {
-  const opts = { instantiate: false, singleton: false };
+  let opts = { instantiate: false, singleton: false };
   setupOwner.call(this);
   this.registry.register('model:post', Post, opts);
   this.registry.register('model:author', Author, opts);
@@ -56,6 +56,17 @@ export function setup() {
   this.registry.register('model:person', Person, opts);
   this.registry.register('model:employee', Employee, opts);
   this.registry.register('model:supervisor', Supervisor, opts);
+}
+
+export function mockServices() {
+  let types = Ember.String.w('posts authors comments commenters people employees supervisors');
+  let mockService = Ember.Service.extend({
+    cacheLookup(/*id*/) { return undefined; },
+    findRelated() { return Ember.RSVP.resolve(null); }
+  });
+  for (let i = 0; i < types.length; i++) {
+    this.registry.register('service:' + types[i], mockService);
+  }
 }
 
 function setupOwner() {

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,5 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
-import { setup, teardown } from 'dummy/tests/helpers/resources';
+import { setup, teardown, mockServices } from 'dummy/tests/helpers/resources';
 
 import authorMock from 'fixtures/api/authors/1';
 import postMock from 'fixtures/api/posts/1';
@@ -53,6 +53,7 @@ test('#serializeResource with only attributes data', function(assert) {
 
 test('#serializeResource with attributes and relationship', function(assert) {
   const serializer = this.subject();
+  mockServices.call(this);
   let resource = this.container.lookup('model:post').create({
     attributes: postMock.data.attributes
   });


### PR DESCRIPTION
Enhances behavior of adding and removing relationships to a resource.

On a Resource object, with related (computed properties) proxy objects, the `addRelationship` and `removeRelationship` will utilize the related service's cache data to add (assign) or remove the related resource via the `content` of the related proxy object. Resource objects that have `isNew` set to true will use proxy objects as well, (no related promise proxy, only a proxy). Creating a resource with relations requires the `relationships` object to include a `links` object with a `related` property that is the URL for the relationship data.