### PR TITLE
Fix typos on questions page

### DIFF
--- a/questions/index.html
+++ b/questions/index.html
@@ -35,7 +35,7 @@
       <h3>Is this a replacement for Ember Data or an interface to it?</h3>
 
       <p><strong>Neither</strong>. This is a completely separate solution. Ember Data needs <em>foreign keys</em> 
-      and provides an abstraction for adaters and serializers. It's solution helps you work 
+      and provides an abstraction for adapters and serializers. It's solution helps you work 
       with various JSON document formats. Ember JSON API Resources needs <em>URLs</em> and fits
       a specific specification for an API server without the need for an abstraction.</p>
 
@@ -69,7 +69,7 @@
       of an adapter, cache mixin, and associated serializer for the same entity. The service
       is an extension of that adapter with a mixin for the caching strategy for that entity.
       The default <code>service-cache</code> mixin provides a basic caching plan using a time value
-      for exiration, which is a property of the resource (defaults to 7 minutes).</p>
+      for expiration, which is a property of the resource (defaults to 7 minutes).</p>
 
 
       <footer class="site-footer">


### PR DESCRIPTION
Fixes a few typos in the docs

- `adaters` -> `adapters`
- `exiration` -> `expiration`