### PR TITLE
Fix promise from cache for related proxy

### DIFF
--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -144,8 +144,9 @@ const RelatedProxyUtil = Ember.Object.extend({
   promiseFromCache(resource, relation, service) {
     let data = resource.get('relationships.' + relation + '.data');
     if (!data) { return; }
-    let content = Ember.A([]), found;
+    let content, found;
     if (Array.isArray(data)) {
+      content = Ember.A([]);
       for (let i = 0; i < data.length; i++) {
         found = this.serviceCacheLookup(service, data[i]);
         if (found) {
@@ -156,7 +157,7 @@ const RelatedProxyUtil = Ember.Object.extend({
     } else {
       content = this.serviceCacheLookup(service, data);
     }
-    return (content && content.length > 0) ? Ember.RSVP.Promise.resolve(content) : null;
+    return (content) ? Ember.RSVP.Promise.resolve(content) : null;
   },
 
   /**

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -8,7 +8,7 @@ const mockService = function () {
   let sandbox = this.sandbox;
   return Ember.Service.extend({
     findRelated: sandbox.spy(function () { return Ember.RSVP.Promise.resolve(Ember.Object.create({id: 1})); }),
-    cacheLookup: sandbox.spy(function () { return Ember.A([]); })
+    cacheLookup: sandbox.spy(function () { return undefined; })
   });
 };
 let entities = ['post', 'author'];
@@ -36,23 +36,12 @@ test('hasOne() helper sets up a promise proxy to a related resource', function(a
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {
-        data: { type: 'authors', id: '2' },
+        data: { type: 'authors', id: '1' },
         links: {
           'self': 'http://api.pixelhandler.com/api/v1/posts/1/relationships/author',
           'related': 'http://api.pixelhandler.com/api/v1/posts/1/author'
         }
       },
-    }
-  });
-  this.container.lookup('model:author').create({
-    id: '2', attributes: { name: 'Bill' },
-    relationships: {
-      posts: {
-        links: {
-          "self": "http://api.pixelhandler.com/api/v1/authors/2/relationships/posts",
-          "related": "http://api.pixelhandler.com/api/v1/authors/2/posts"
-        }
-      }
     }
   });
   let promise = post.get('author');


### PR DESCRIPTION
Lookup result for cached content can be an object or an array, remove condition that only returned cache for an array result.