### PR TITLE
Tune up blueprints, use in addons, add jsonapi-blueprint

### DIFF
--- a/app/blueprints/ember-jsonapi-resources.js
+++ b/app/blueprints/ember-jsonapi-resources.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-jsonapi-resources/blueprints/ember-jsonapi-resources';

--- a/app/blueprints/resource.js
+++ b/app/blueprints/resource.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-jsonapi-resources/blueprints/resource';

--- a/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
+++ b/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
@@ -1,5 +1,5 @@
 <%= importStatement %>
-import config from '<%= dasherizedPackageName %>/config/environment';
+import config from '../config/environment';
 
 export default <%= baseClass %>.extend({
   type: '<%= entity %>',

--- a/blueprints/jsonapi-adapter/index.js
+++ b/blueprints/jsonapi-adapter/index.js
@@ -58,6 +58,14 @@ module.exports = {
           blueprintName = 'adapter';
         }
         return inflector.pluralize(blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        } else if (options.inAddon) {
+          return 'app';
+        }
+        return 'app';
       }
     };
   }

--- a/blueprints/jsonapi-blueprint/files/blueprints/.jshintrc
+++ b/blueprints/jsonapi-blueprint/files/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/jsonapi-blueprint/files/blueprints/__name__/index.js
+++ b/blueprints/jsonapi-blueprint/files/blueprints/__name__/index.js
@@ -1,0 +1,13 @@
+/*jshint node:true*/
+module.exports = {
+  description: '<%= name %>',
+
+  normalizeEntityName: function () {},
+
+  afterInstall: function(options) {
+    return this.addPackagesToProject([{
+      name: 'ember-jsonapi-resources',
+      target: '~1.1.2'
+    }]);
+  }
+};

--- a/blueprints/jsonapi-blueprint/index.js
+++ b/blueprints/jsonapi-blueprint/index.js
@@ -1,0 +1,10 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'jsonapi-blueprint, generates addon blueprint (use addon name)',
+
+  anonymousOptions: ['name'],
+
+  locals: function(options) {
+    return { name: options.args[1] };
+  }
+};

--- a/blueprints/jsonapi-initializer/index.js
+++ b/blueprints/jsonapi-initializer/index.js
@@ -48,6 +48,14 @@ module.exports = {
         }
         var blueprintName = options.originBlueprintName.replace('jsonapi-', '');
         return inflector.pluralize(blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        } else if (options.inAddon) {
+          return 'app';
+        }
+        return 'app';
       }
     };
   }

--- a/blueprints/jsonapi-model/files/__root__/__path__/__name__.js
+++ b/blueprints/jsonapi-model/files/__root__/__path__/__name__.js
@@ -1,10 +1,22 @@
 import Ember from 'ember';
-import Resource from '<%= resourcePath %>';
+import Resource from 'ember-jsonapi-resources/models/resource';
 import { attr, hasOne, hasMany } from 'ember-jsonapi-resources/models/resource';
 
-export default Resource.extend({
+let <%= classifiedModuleName %> = Resource.extend({
   type: '<%= resource %>',
   service: Ember.inject.service('<%= resource %>'),
 
   <%= attrs %>
 });
+
+<%= classifiedModuleName %>.reopenClass({
+
+  getDefaults() {
+    return {
+      isNew: true,
+      attributes: {}
+    };
+  }
+});
+
+export default <%= classifiedModuleName %>;

--- a/blueprints/jsonapi-model/index.js
+++ b/blueprints/jsonapi-model/index.js
@@ -56,18 +56,15 @@ module.exports = {
     needs = '  needs: [' + needsDeduplicated.join(', ') + '],';
 
     var relativePath = pathUtil.getRelativePath(resource);
-    var baseResourcePath = relativePath + 'resource';
     if (options.pod) {
       relativePath = pathUtil.getRelativeParentPath(resource);
-      baseResourcePath = relativePath + ['models', 'resource'].join('/');
     }
 
     return {
       attrs: attrs,
       needs: needs,
       entity: stringUtils.dasherize(inflection.singularize(resource)),
-      resource: stringUtils.dasherize(inflection.pluralize(resource)),
-      resourcePath: baseResourcePath
+      resource: stringUtils.dasherize(inflection.pluralize(resource))
     };
   },
 

--- a/blueprints/jsonapi-resource/index.js
+++ b/blueprints/jsonapi-resource/index.js
@@ -31,6 +31,7 @@ module.exports = {
         return mainBlueprint[type](options);
       })
       .then(function() {
+        if (name === 'addon-import') { return; }
         var testBlueprint = mainBlueprint.lookupBlueprint(name + '-test', {
           ui: this.ui,
           analytics: this.analytics,
@@ -56,24 +57,20 @@ module.exports = {
     var modelOptions = merge({}, options, {
       entity: {
         name: entityName ? inflection.singularize(entityName) : ''
-      }
+      },
+      originBlueprintName: 'jsonapi-model'
     });
 
     var otherOptions = merge({}, options);
 
-    var self = this;
-    return this._processBlueprint(type, 'jsonapi-model', modelOptions)
-    .then(function() {
-      return self._processBlueprint(type, 'jsonapi-adapter', otherOptions)
-      .then(function() {
-        return self._processBlueprint(type, 'jsonapi-serializer', otherOptions)
-        .then(function() {
-          return self._processBlueprint(type, 'jsonapi-service', otherOptions)
-          .then(function() {
-            return self._processBlueprint(type, 'jsonapi-initializer', otherOptions);
-          });
-        });
-      });
-    });
+    return Promise.all([
+      this._processBlueprint(type, 'jsonapi-model', modelOptions),
+      this._processBlueprint(type, 'addon-import', modelOptions),
+      this._processBlueprint(type, 'jsonapi-adapter', otherOptions),
+      this._processBlueprint(type, 'jsonapi-serializer', otherOptions),
+      this._processBlueprint(type, 'jsonapi-service', otherOptions),
+      this._processBlueprint(type, 'jsonapi-adapter', otherOptions),
+      this._processBlueprint(type, 'jsonapi-initializer', otherOptions)
+    ]);
   }
 };

--- a/blueprints/jsonapi-serializer/index.js
+++ b/blueprints/jsonapi-serializer/index.js
@@ -41,6 +41,14 @@ module.exports = {
           blueprintName = 'serializer';
         }
         return inflector.pluralize(blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        } else if (options.inAddon) {
+          return 'app';
+        }
+        return 'app';
       }
     };
   }

--- a/blueprints/jsonapi-service/index.js
+++ b/blueprints/jsonapi-service/index.js
@@ -43,6 +43,14 @@ module.exports = {
           blueprintName = 'service';
         }
         return inflector.pluralize(blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        } else if (options.inAddon) {
+          return 'app';
+        }
+        return 'app';
       }
     };
   }


### PR DESCRIPTION
- Use relative path for config in adapter blueprint
- Add `__root__` blueprints, used inside addon the root will be `app` where needed
- Resource blueprint uses app and addon files for models
- Add `jsonapi-blueprint` to generate blueprints for addons (name of the addon)
  - Generated blueprints add the `ember-jsonapi-resources` package to consuming project in `afterInstall`
- Model blueprint imports `resource` using full path (from addon directory)
- Add `getDefaults` class method in Model blueprint
