### PR TITLE
Fix es6-promise bower dependency

### DIFF
--- a/blueprints/ember-jsonapi-resources/index.js
+++ b/blueprints/ember-jsonapi-resources/index.js
@@ -9,7 +9,7 @@ module.exports = {
     return Promise.all([
       this.addBowerPackagesToProject([
         { name: 'fetch' },
-        { name: 'es6-promise' }
+        { name: 'es6-promise', target: '~3.0.2' }
       ]),
       this.addPackagesToProject([
         { name: 'inflection', target: '~1.7.1' },


### PR DESCRIPTION
Addon is broken with latest versions of es6-promise, because of wrong import. This PR is fixed es6-promise package version to 3.0.2