### PR TITLE
Update relationships with resource

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -182,14 +182,21 @@ export default Ember.Object.extend(FetchMixin, Evented, {
 
     @method updateResource
     @param {Resource} resource instance to serialize the changed attributes
+    @param {Array} includeRelationships (optional) list of {String} relationships
+      to opt-into an update
     @return {Promise} resolves with PATCH response or `null` if nothing to update
   */
-  updateResource(resource) {
+  updateResource(resource, includeRelationships = false) {
     let url = resource.get('links.self') || this.get('url') + '/' + resource.get('id');
-    const json = this.serializer.serializeChanged(resource);
-    if (!json) {
+    let json = this.serializer.serializeChanged(resource);
+    let relationships = this.serializer.serializeRelationships(resource, includeRelationships);
+    if ((includeRelationships &&
+          ((!json && !relationships) || (!json && relationships.length === 0))) ||
+        (!includeRelationships && !json)) {
       return RSVP.Promise.resolve(null);
     }
+    json = json || { data: { id: resource.get('id'), type: resource.get('type') } };
+    json.data.relationships = relationships;
     return this.fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(json),
@@ -240,7 +247,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   createRelationship(resource, relationship, id) {
     return this.fetch(this._urlForRelationship(resource, relationship), {
       method: 'POST',
-      body: JSON.stringify(this._payloadForRelationship(resource, relationship, id))
+      body: JSON.stringify(this.serializer.serializeRelationship(resource, relationship, id))
     });
   },
 
@@ -280,7 +287,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   patchRelationship(resource, relationship) {
     return this.fetch(this._urlForRelationship(resource, relationship), {
       method: 'PATCH',
-      body: JSON.stringify(this._payloadForRelationship(resource, relationship))
+      body: JSON.stringify(this.serializer.serializeRelationship(resource, relationship))
     });
   },
 
@@ -310,7 +317,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   deleteRelationship(resource, relationship, id) {
     return this.fetch(this._urlForRelationship(resource, relationship), {
       method: 'DELETE',
-      body: JSON.stringify(this._payloadForRelationship(resource, relationship, id))
+      body: JSON.stringify(this.serializer.serializeRelationship(resource, relationship, id))
     });
   },
 
@@ -322,26 +329,9 @@ export default Ember.Object.extend(FetchMixin, Evented, {
     @return {String} url
   */
   _urlForRelationship(resource, relationship) {
-    let meta = resource.constructor.metaForProperty(relationship);
+    let meta = resource.relationMetadata(relationship);
     let url  = resource.get(['relationships', meta.relation, 'links', 'self'].join('.'));
     return url || [this.get('url'), resource.get('id'), 'relationships', relationship].join('/');
-  },
-
-  /**
-    @method _payloadForRelationship
-    @private
-    @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
-    @param {String} id the id for the related resource or undefined current relationship data
-    @return {Object} payload
-  */
-  _payloadForRelationship(resource, relationship, id) {
-    // actual resource type of this relationship is found in related-proxy's meta.
-    let meta  = resource.constructor.metaForProperty(relationship);
-    let data  = resource.get(['relationships', meta.relation, 'data'].join('.'));
-    if (id === undefined) { return {data: data}; }
-    let resourceObject = { type: pluralize(meta.type), id: id.toString() };
-    return { data: (Array.isArray(data)) ? [resourceObject] : resourceObject };
   },
 
   /**

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -240,7 +240,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
 
     @method createRelationship
     @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
+    @param {String} relationship name
     @param {String} id of the related resource
     @return {Promise}
   */
@@ -281,7 +281,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
 
     @method patchRelationship
     @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
+    @param {String} relationship
     @return {Promise}
   */
   patchRelationship(resource, relationship) {
@@ -310,7 +310,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
 
     @method deleteRelationship
     @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
+    @param {String} relationship name
     @param {String} id of the related resource
     @return {Promise}
   */
@@ -325,7 +325,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
     @method _urlForRelationship
     @private
     @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
+    @param {String} relationship name
     @return {String} url
   */
   _urlForRelationship(resource, relationship) {

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -249,8 +249,8 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
       ref.changed = identity;
       ref.previous = ref.previous || last;
     } else if (meta && meta.kind === 'hasMany') {
-      ref.added = ref.added || [];
-      ref.removals = ref.removals || [];
+      ref.added = ref.added || Ember.A([]);
+      ref.removals = ref.removals || Ember.A([]);
       let id = identity.id;
       if (ref.removals.findBy('id', id)) {
         ref.removals = ref.removals.rejectBy('id', id);
@@ -318,13 +318,13 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
       // TODO can previous be falsy, ok to be null but not undefined ?
       ref.previous = ref.previous || this.get('relationships.' + relation);
     } else if (meta.kind === 'hasMany') {
-      ref.added = ref.added || [];
-      ref.removals = ref.removals || [];
+      ref.added = ref.added || Ember.A([]);
+      ref.removals = ref.removals || Ember.A([]);
       if (ref.added.findBy('id', id)) {
-        ref.added = ref.added.rejectBy('id', id);
+        ref.added = Ember.A(ref.added.rejectBy('id', id));
       }
       if (!ref.removals.findBy('id', id)) {
-        ref.removals.push({type: pluralize(relation), id: id});
+        ref.removals.push({ type: pluralize(relation), id: id });
       }
     }
   },
@@ -436,9 +436,9 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
             this.addRelationship(relation, ref.previous.id);
           }
         } else if (meta && meta.kind === 'hasMany') {
-          ref.added = ref.added || [];
+          ref.added = ref.added || Ember.A([]);
           let added = ref.added.mapBy('id');
-          ref.removals = ref.removals || [];
+          ref.removals = ref.removals || Ember.A([]);
           let removed = ref.removals.mapBy('id');
           added.forEach( (id) => {
             this.removeRelationship(relation, id);

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -290,7 +290,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
         resources.removeAt(idx);
       }
     } else if (typeof relation === 'object') {
-      if (relation.data[related]) {
+      if (relation.data.type === pluralize(related) && relation.data.id === id) {
         this._relationRemoved(related, id);
       }
       relation.data = null;
@@ -312,11 +312,11 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     setupRelationshipTracking.call(this, relation, meta.kind);
     if (meta.kind === 'hasOne') {
       ref.changed = null;
-      ref.previous = ref.previous || this.get('relationships.' + relation);
+      ref.previous = ref.previous || this.get('relationships.' + relation).data;
     } else if (meta.kind === 'hasMany') {
       ref.added = Ember.A(ref.added.rejectBy('id', id));
       if (!ref.removals.findBy('id', id)) {
-        ref.removals.push({ type: pluralize(relation), id: id });
+        ref.removals.pushObject({ type: pluralize(relation), id: id });
       }
     }
   },
@@ -368,7 +368,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
         return !!ref.previous || (ref.removals && ref.removals.length) ||
           (ref.added && ref.added.length);
       });
-      return relationships;
+      return Ember.A(relationships);
     }
   }).volatile(),
 

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -123,7 +123,7 @@ export default Ember.Object.extend({
   /**
     @method serializeRelationship
     @param {Resource} resource instance, has URLs via it's relationships property
-    @param {String} relationship name (plural) to find the url from the resource instance
+    @param {String} relationship name
     @param {String|undefined} id (optional) of the related resource
     @return {Object} payload
   */

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -59,11 +59,13 @@ export default Ember.Service.extend({
     @method updateResource
     @param {String} type the entity or resource name will be pluralized
     @param {Resource} resource instance to serialize the changed attributes
+    @param {Array} includeRelationships (optional) list of {String} relationships
+      to opt-into an update
     @return {Promise}
   */
-  updateResource(type, resource) {
+  updateResource(type, resource, includeRelationships = false) {
     let service = this._service(type);
-    return service.updateResource(resource);
+    return service.updateResource(resource, includeRelationships);
   },
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-jsonapi-resources",
   "dependencies": {
-    "ember": "~2.8.0",
+    "ember": "~2.8.1",
     "ember-cli-shims": "0.1.1",
     "fetch": "~0.10.1",
     "es6-promise": "~3.0.2"

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -415,20 +415,19 @@ test('#createRelationship (to-one)', function(assert) {
   const done = assert.async();
 
   let adapter = this.subject({type: 'posts', url: '/posts'});
-  adapter.serializer = mockSerializer();
+  let mockRelationSerialized = { data: { type: 'authors', id: '1'} };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   mockServices.call(this);
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.createRelationship(resource, 'author', '1');
-  debugger;
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: {type: 'authors', id: '1'}});
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.author.links.self,
-        {method: 'POST', body: jsonBody}
+        {method: 'POST', body: JSON.stringify(mockRelationSerialized)}
       ),
       '#fetch called with url and options with data'
     );
@@ -442,17 +441,18 @@ test('#createRelationship uses optional resource type', function (assert) {
 
   mockServices.call(this);
   let adapter = this.subject({type: 'supervisors', url: '/supervisors'});
+  let mockRelationSerialized = { data: [{ type: 'employees', id: '1' }] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
   let promise = adapter.createRelationship(resource, 'directReports', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: [{type: 'employees', id: '1'}]});
     assert.ok(
       adapter.fetch.calledWith(
         supervisorMock.data.relationships['direct-reports'].links.self,
-        {method: 'POST', body: jsonBody}
+        { method: 'POST', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -465,18 +465,19 @@ test('#deleteRelationship (to-many)', function(assert) {
   const done = assert.async();
 
   mockServices.call(this);
-  let adapter = this.subject({type: 'posts', url: '/posts'});
+  let adapter = this.subject({ type: 'posts', url: '/posts' });
+  let mockRelationSerialized = { data: [{ type: 'comments', id: '1' }] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.deleteRelationship(resource, 'comments', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: [{type: 'comments', id: '1'}]});
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.comments.links.self,
-        {method: 'DELETE', body: jsonBody}
+        { method: 'DELETE', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -490,17 +491,18 @@ test('#deleteRelationship (to-one)', function(assert) {
 
   mockServices.call(this);
   const adapter = this.subject({type: 'posts', url: '/posts'});
+  let mockRelationSerialized = { data: { type: 'authors', id: '1' } };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   let promise = adapter.deleteRelationship(resource, 'author', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: {type: 'authors', id: '1'}});
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.author.links.self,
-        {method: 'DELETE', body: jsonBody}
+        { method: 'DELETE', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -514,17 +516,18 @@ test('#deleteRelationship uses optional resource type', function (assert) {
 
   mockServices.call(this);
   let adapter = this.subject({type: 'supervisors', url: '/supervisors'});
+  let mockRelationSerialized = { data: [{ type: 'employees', id: '1' }] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
   let promise = adapter.deleteRelationship(resource, 'directReports', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: [{type: 'employees', id: '1'}]});
     assert.ok(
       adapter.fetch.calledWith(
         supervisorMock.data.relationships['direct-reports'].links.self,
-        {method: 'DELETE', body: jsonBody}
+        { method: 'DELETE', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -538,6 +541,8 @@ test('#patchRelationship (to-many)', function(assert) {
 
   mockServices.call(this);
   let adapter = this.subject({type: 'posts', url: '/posts'});
+  let mockRelationSerialized = { data: [{ type: 'comments', id: '1' }] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   resource.addRelationship('comments', '1');
@@ -545,11 +550,10 @@ test('#patchRelationship (to-many)', function(assert) {
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: [{type: 'comments', id: '1'}]});
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.comments.links.self,
-        {method: 'PATCH', body: jsonBody}
+        { method: 'PATCH', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -563,6 +567,8 @@ test('#patchRelationship (to-one)', function(assert) {
 
   mockServices.call(this);
   const adapter = this.subject({type: 'posts', url: '/posts'});
+  let mockRelationSerialized = { data: { type: 'authors', id: '1' } };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   resource.addRelationship('author', '1');
@@ -570,11 +576,10 @@ test('#patchRelationship (to-one)', function(assert) {
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: {type: 'authors', id: '1'}});
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.author.links.self,
-        {method: 'PATCH', body: jsonBody}
+        { method: 'PATCH', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -588,6 +593,8 @@ test('#patchRelationship uses optional resource type', function (assert) {
 
   mockServices.call(this);
   let adapter = this.subject({type: 'supervisors', url: '/supervisors'});
+  let mockRelationSerialized = { data: [{type: 'employees', id: '1'}] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
   resource.addRelationship('directReports', '1');
@@ -595,11 +602,10 @@ test('#patchRelationship uses optional resource type', function (assert) {
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
-    let jsonBody = JSON.stringify({data: [{type: 'employees', id: '1'}]});
     assert.ok(
       adapter.fetch.calledWith(
         supervisorMock.data.relationships['direct-reports'].links.self,
-        {method: 'PATCH', body: jsonBody}
+        { method: 'PATCH', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#fetch called with url and options with data'
     );
@@ -617,17 +623,18 @@ test('createRelationship casts id to string', function (assert) {
 
   mockServices.call(this);
   const adapter = this.subject({type: 'posts', url: '/posts'});
+  let mockRelationSerialized = { data: [{type: 'comments', id: '1'}] };
+  adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
   let resource = this.container.lookup('model:post').create(postMock.data);
   let createPromise = adapter.createRelationship(resource, 'comments', 1);
   let deletePromise = adapter.deleteRelationship(resource, 'comments', 1);
 
-  let jsonBody = JSON.stringify({data: [{type: 'comments', id: '1'}]});
   createPromise.then(() => {
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.comments.links.self,
-        {method: 'POST', body: jsonBody}
+        { method: 'POST', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#createRelationship casts id to String'
     );
@@ -636,7 +643,7 @@ test('createRelationship casts id to string', function (assert) {
     assert.ok(
       adapter.fetch.calledWith(
         postMock.data.relationships.comments.links.self,
-        {method: 'DELETE', body: jsonBody}
+        { method: 'DELETE', body: JSON.stringify(mockRelationSerialized) }
       ),
       '#deleteRelationship casts id to String'
     );

--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -495,7 +495,7 @@ test('#updateRelationship, from resource-operations mixin', function(assert) {
     return RSVP.Promise.resolve(null);
   });
   let post = this.container.lookup('model:post').create({
-    id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
+    id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.' },
     relationships: {
       author: { data: { type: 'authors', id: '2' }, links: { related: 'url-here'} },
       comments: { data: [{ type: 'comments', id: '4' }], links: { related: 'url-here'} }

--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -491,8 +491,8 @@ test('#changedRelationships', function(assert) {
   post.removeRelationships('comments', ['3']);
   let changes = post.get('changedRelationships');
   assert.equal(changes.length, 2, 'two relationships were changed');
-  assert.ok(changes.includes('author'), 'author relationship was changed');
-  assert.ok(changes.includes('comments'), 'comments relationship was changed');
+  assert.ok(changes.indexOf('author') > -1, 'author relationship was changed');
+  assert.ok(changes.indexOf('comments') > -1, 'comments relationship was changed');
 });
 
 test('#didResolveProxyRelation', function(assert) {

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -94,6 +94,43 @@ test('when #serializedChanged has nothing to return', function(assert) {
   assert.equal(serialized, null, 'null is returned when there are no changed attributes');
 });
 
+test('#serializeRelationship', function(assert) {
+  const serializer = this.subject();
+  mockServices.call(this);
+  let post = createPost.call(this);
+  let json = serializer.serializeRelationship(post, 'author');
+  assert.deepEqual(json, { data: { type: 'authors', id: '2' } }, 'author serialized');
+  json = serializer.serializeRelationship(post, 'comments');
+  assert.deepEqual(json, { data: [{ type: 'comments', id: '3' }] }, 'comments serialized');
+});
+
+test('#serializeRelationships', function(assert) {
+  const serializer = this.subject();
+  mockServices.call(this);
+  let post = createPost.call(this);
+  let json = serializer.serializeRelationships(post, ['author', 'comments']);
+  assert.deepEqual(json, {
+    author: { data: { type: 'authors', id: '2' } },
+    comments: { data: [{ type: 'comments', id: '3' }] }
+  }, 'author and comments relationships serialized');
+});
+
+function createPost() {
+  return this.container.lookup('model:post').create({
+    id: '1', attributes: {
+      title: 'Wyatt Earp', excerpt: 'Was a gambler.'
+    },
+    relationships: {
+      author: {
+        data: { type: 'authors', id: '2' }, links: { related: 'url' }
+      },
+      comments: {
+        data: [{ type: 'comments', id: '3' }], links: { related: 'url' }
+      }
+    }
+  });
+}
+
 test('With data as an object #deserialize calls #deserializeResource', function(assert) {
   const serializer = this.subject();
   sandbox.stub(serializer, 'deserializeResource', function () {});


### PR DESCRIPTION
- Add relationship change tracking to the Resource
- Add `rollbackRelationships` method
- Change `rollback` to call both `rollbackAttributes` and `rollbackRelationships`
- Add `changedRelationships` property and `relationMetadata` method to Resource
- Add new relationship serialization methods
- Add optional second parameter `includeRelationships ` to `ApplicationAdapter#updateResource` method to patch relationships
  - Opt into what relationships to patch using an array of the relationships (names, e.g. `['author', 'comments']`