### PR TITLE
Improve relationMetadata error handling/throwing

### DIFF
--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -471,7 +471,15 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     try {
       meta = this.constructor.metaForProperty(property);
     } catch (e) {
-      meta = this.get('content').constructor.metaForProperty(property);
+      // Could be a Ember Proxy object. Try that, otherwise throw original error.
+      // This could contain a very useful message ("could not find computed property
+      // with key `property`" on undefined relationships for example)
+      const content = this.get('content');
+      if (content && content.constructor.metaForProperty) {
+        meta = content.constructor.metaForProperty(property);
+      } else {
+        throw e;
+      }
     }
     return meta;
   },


### PR DESCRIPTION
Small improvement: re-throw error if we can't fall back on ObjectProxy. This brings up very useful error messages like `Assertion Failed: metaForProperty() could not find a computed property with key 'bonus-malus-table'.`, in this case caused by an undefined relationship clientside.