### PR TITLE
Fix for using ember-json-api-resources with es6-promise 3.2.x and above.

### DIFF
--- a/blueprints/ember-jsonapi-resources/index.js
+++ b/blueprints/ember-jsonapi-resources/index.js
@@ -9,7 +9,7 @@ module.exports = {
     return Promise.all([
       this.addBowerPackagesToProject([
         { name: 'fetch' },
-        { name: 'es6-promise', target: '~3.0.2' }
+        { name: 'es6-promise', target: '^4.0.5' }
       ]),
       this.addPackagesToProject([
         { name: 'inflection', target: '~1.7.1' },

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "ember": "~2.8.1",
     "ember-cli-shims": "0.1.1",
     "fetch": "~0.10.1",
-    "es6-promise": "~3.0.2"
+    "es6-promise": "^4.0.5"
   },
   "devDependencies": {
     "sinon": "http://sinonjs.org/releases/sinon-1.15.0.js",

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = {
     // addon passed as an app doesn't define app.import
     if (typeof app.import === 'function') {
       app.import({
-        development: app.bowerDirectory + '/es6-promise/promise.js',
-        production: app.bowerDirectory + '/es6-promise/promise.min.js'
+        development: app.bowerDirectory + '/es6-promise/es6-promise.js',
+        production: app.bowerDirectory + '/es6-promise/es6-promise.min.js'
       });
 
       app.import(app.bowerDirectory + '/fetch/fetch.js');


### PR DESCRIPTION
Bump dependency for es6-promise to 4.0.5 and change the location and name of where to find the file.