### PR TITLE
Remove deprecation warnings with use of this.container.lookupFactory

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -41,7 +41,14 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   */
   url: Ember.computed('type', {
     get() {
-      const config = this.container.lookupFactory('config:environment');
+      let config;
+
+      if (typeof Ember.getOwner === 'function') {
+        config = Ember.getOwner(this).resolveRegistration('config:environment');
+      } else {
+        config = this.container.lookupFactory('config:environment');
+      }
+
       const enclosingSlashes = /^\/|\/$/g;
       const host = config.APP.API_HOST.replace(enclosingSlashes, '');
       const path = config.APP.API_PATH.replace(enclosingSlashes, '');

--- a/addon/mixins/adapter-api-host-proxy.js
+++ b/addon/mixins/adapter-api-host-proxy.js
@@ -12,7 +12,14 @@ import Ember from 'ember';
 */
 export default Ember.Mixin.create({
 	fetchUrl: function(url) {
-    const config = this.container.lookupFactory('config:environment');
+		let config;
+
+		if (typeof Ember.getOwner === 'function') {
+			config = Ember.getOwner(this).resolveRegistration('config:environment');
+		} else {
+			config = this.container.lookupFactory('config:environment');
+		}
+		
     const proxy  = config.APP.API_HOST_PROXY;
     const host   = config.APP.API_HOST;
     if (proxy && host) {


### PR DESCRIPTION
Add branching logic to remove deprecation warnings on using this.container.lookupFactory.

Discussion around this issue here:
http://discuss.emberjs.com/t/best-practices-accessing-app-config-from-addon-code/7006/20