### PR TITLE
Remove usage of this.container completely.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,24 +12,15 @@ cache:
 env:
   # - EMBER_TRY_SCENARIO=default
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-2.0.3
-  - EMBER_TRY_SCENARIO=ember-2.1.2
-  - EMBER_TRY_SCENARIO=ember-2.2.2
-  - EMBER_TRY_SCENARIO=ember-2.3.1
-  - EMBER_TRY_SCENARIO=ember-2.5.1
-  - EMBER_TRY_SCENARIO=ember-2.6.2
-  - EMBER_TRY_SCENARIO=ember-2.7.3
-  - EMBER_TRY_SCENARIO=ember-2.8.2
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -41,7 +41,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   */
   url: Ember.computed('type', {
     get() {
-      const config = this.container.lookupFactory('config:environment');
+      const config = getOwner(this).resolveRegistration('config:environment');
       const enclosingSlashes = /^\/|\/$/g;
       const host = config.APP.API_HOST.replace(enclosingSlashes, '');
       const path = config.APP.API_PATH.replace(enclosingSlashes, '');
@@ -137,8 +137,7 @@ export default Ember.Object.extend(FetchMixin, Evented, {
       type = resource.type;
     }
     // use resource's service if in container, otherwise use this service to fetch
-    let owner = (typeof getOwner === 'function') ? getOwner(this) : this.container;
-    let service = owner.lookup('service:' + pluralize(type)) || this;
+    let service = getOwner(this).lookup('service:' + pluralize(type)) || this;
     url = this.fetchUrl(url);
     return service.fetch(url, { method: 'GET' });
   },

--- a/addon/mixins/adapter-api-host-proxy.js
+++ b/addon/mixins/adapter-api-host-proxy.js
@@ -4,6 +4,8 @@
 **/
 import Ember from 'ember';
 
+const { getOwner } = Ember;
+
 /**
   Mixin to provide url rewrite for proxied api. Mostly used as example.
 
@@ -12,7 +14,7 @@ import Ember from 'ember';
 */
 export default Ember.Mixin.create({
 	fetchUrl: function(url) {
-    const config = this.container.lookupFactory('config:environment');
+    const config = getOwner(this).resolveRegistration('config:environment');
     const proxy  = config.APP.API_HOST_PROXY;
     const host   = config.APP.API_HOST;
     if (proxy && host) {

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -21,8 +21,7 @@ const { getOwner, computed, Logger } = Ember;
   use the owner API or the container to `lookup` the factory, for example:
 
   ```js
-  let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
-  let model = owner.lookup('model:entity').create({ attributes: { key: value } });
+  let model = Ember.getOwner(this).lookup('model:entity').create({ attributes: { key: value } });
   ```
 
   See <http://jsonapi.org/format/#document-resource-objects>
@@ -208,8 +207,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     let data = this.get(key);
     let type = pluralize(meta.type);
     let identifier = { type: type, id: id };
-    let owner = (typeof getOwner === 'function') ? getOwner(this) : this.container;
-    let resource = owner.lookup(`service:${type}`).cacheLookup(id);
+    let resource = getOwner(this).lookup(`service:${type}`).cacheLookup(id);
     if (Array.isArray(data)) {
       this._relationAdded(related, identifier);
       data.push(identifier);
@@ -558,7 +556,7 @@ Resource.reopenClass({
 
     ```
     model() {
-      let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+      let owner = Ember.getOwner(this);
       return owner.lookup('model:post').create({
         attributes: {
           title: 'The JSON API 1.0 Spec Rocks!'
@@ -604,12 +602,12 @@ Resource.reopenClass({
     if (!type) {
       Logger.warn(msg + '#create called, instead you should first use ' + msg + '.extend({type:"entity"})');
     } else {
-      let owner = (typeof getOwner === 'function') ? getOwner(instance) : instance.container;
+      let owner = getOwner(instance);
       if (owner) {
         useComputedPropsMetaToSetupRelationships(owner, factory, instance);
       } else {
         msg += '#create should only be called from a container lookup (relationships not setup), instead use: \n';
-        msg += "`let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container; \n";
+        msg += "`let owner = Ember.getOwner(this); \n";
         msg += 'owner.lookup("' + factory + '").create()`';
         Logger.warn(msg);
       }

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -214,8 +214,7 @@ export default Ember.Object.extend({
     if (!related) { return; }
     let resource, service;
     for (let i = 0; i < related.length; i++) {
-      let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
-      service = owner.lookup('service:' + pluralize(related[i].type));
+      service = Ember.getOwner(this).lookup('service:' + pluralize(related[i].type));
       if (service && service.cache && service.cache.data) {
         resource = service.serializer.deserializeResource(related[i]);
         service.cacheResource({ meta: resp.meta, data: resource, headers: resp.headers});
@@ -298,8 +297,7 @@ export default Ember.Object.extend({
     @return {Function} factory for creating resource instances
   */
   _lookupFactory(type) {
-    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
-    return owner.lookup('model:' + singularize(type));
+    return Ember.getOwner(this).lookup('model:' + singularize(type));
   }
 });
 

--- a/blueprints/jsonapi-model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/jsonapi-model-test/files/tests/unit/__path__/__test__.js
@@ -15,7 +15,7 @@ moduleFor('model:<%= dasherizedModuleName %>', '<%= friendlyDescription %>', {
 });
 
 test('<%= resource %> has "type" property set to: <%= resource %>', function(assert) {
-  let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+  let owner = Ember.getOwner(this);
   let model = owner.lookup('model:<%= entity %>').create();
   assert.equal(model.get('type'), '<%= resource %>', 'resource has expected type');
 });

--- a/blueprints/jsonapi-serializer-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/jsonapi-serializer-test/files/tests/unit/__path__/__test__.js
@@ -4,11 +4,7 @@ import Ember from 'ember';
 
 moduleFor('serializer:<%= entity %>', '<%= friendlyTestDescription %>', {
   beforeEach() {
-    if (typeof Ember.setOwner === 'function') {
-      Ember.setOwner(Resource.prototype, Ember.getOwner(this));
-    } else {
-      Resource.prototype.container = this.container;
-    }
+    Ember.setOwner(Resource.prototype, Ember.getOwner(this));
     let opts = { instantiate: false, singleton: false };
     this.registry.register('model:<%= entity %>', Resource, opts);
   },
@@ -19,7 +15,7 @@ moduleFor('serializer:<%= entity %>', '<%= friendlyTestDescription %>', {
 
 // Replace this with your real tests.
 test('it serializes resources', function(assert) {
-  let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+  let owner = Ember.getOwner(this);
   let resource = owner.lookup('model:<%= entity %>').create();
   let serializer = this.subject();
   var serializedResource = serializer.serialize(resource);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,17 +1,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {
@@ -19,6 +8,17 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-4'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
         }
       }
     },
@@ -52,89 +52,6 @@ module.exports = {
         },
         resolutions: {
           'ember': 'canary'
-        }
-      }
-    },
-    {
-      name: 'ember-2.0.3',
-      bower: {
-        dependencies: {
-          'ember': '2.0.3'
-        },
-        resolutions: {
-          'ember': '2.0.3'
-        }
-      }
-    },
-    {
-      name: 'ember-2.1.2',
-      bower: {
-        dependencies: {
-          'ember': '2.1.2'
-        },
-        resolutions: {
-          'ember': '2.1.2'
-        }
-      }
-    },
-    {
-      name: 'ember-2.2.2',
-      dependencies: {
-        'ember': '2.2.2'
-      }
-    },
-    {
-      name: 'ember-2.3.1',
-      bower: {
-        dependencies: {
-          'ember': '2.3.1'
-        },
-        resolutions: {
-          'ember': '2.3.1'
-        }
-      }
-    },
-    {
-      name: 'ember-2.5.1',
-      bower: {
-        dependencies: {
-          'ember': '2.5.1'
-        },
-        resolutions: {
-          'ember': '2.5.1'
-        }
-     }
-    },
-    {
-      name: 'ember-2.6.2',
-      bower: {
-        dependencies: {
-          'ember': '2.6.2'
-        },
-        resolutions: {
-          'ember': '2.6.2'
-        }
-      }
-    },
-    {
-      name: 'ember-2.7.3',
-      bower: {
-        dependencies: {
-          'ember': '2.7.3'
-        },
-        resolutions: {
-          'ember': '2.7.3'
-        }
-      }
-    },
-    {
-      name: 'ember-2.8.2',
-      bower: {
-        dependencies: {
-          'ember': '2.8.2'
-        },
-        resolutions: {
-          'ember': '2.8.2'
         }
       }
     }

--- a/tests/dummy/app/routes/admin/create.js
+++ b/tests/dummy/app/routes/admin/create.js
@@ -8,7 +8,7 @@ export default Ember.Route.extend({
   },
 
   model() {
-    let owner = (typeof Ember.getOwner === 'function') ? Ember.getOwner(this) : this.container;
+    let owner = Ember.getOwner(this);
     return owner.lookup('model:post').create({
       isNew: true,
       attributes: { date: new Date() }

--- a/tests/helpers/resources.js
+++ b/tests/helpers/resources.js
@@ -48,13 +48,14 @@ function setupOwner() {
   let ogLookup, ogLookupFactory;
   if (typeof Ember.getOwner === 'function') {
     this.container = this.owner || Ember.getOwner(this);
-    ogLookup = this.container.lookup;
+    ogLookup = Ember.getOwner(this).lookup;
     ogLookupFactory = this.container._lookupFactory;
   } else {
     ogLookup = this._ogContainer.lookup;
     ogLookupFactory = this._ogContainer.lookupFactory;
   }
-  this.container.lookup = function(factory) {
+
+  Ember.getOwner(this).lookup = function(factory) {
     if (factory.match(/^model/) !== null) {
       return ogLookupFactory.call(this, factory);
     } else {

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -73,7 +73,7 @@ test('adapter with ApiHostProxyMixin rewrites API_HOST to API_HOST_PROXY', funct
     }
   });
   this.registry.register('service:posts', Adapter.extend(AdapterApiHostProxyMixin, {type: 'posts'}));
-  const service = this.container.lookup('service:posts');
+  const service = Ember.getOwner(this).lookup('service:posts');
   const url     = service.get('url');
   assert.equal(url, 'http://api.pixelhandler.com/api/v1/posts', 'non-proxied-url ok');
   assert.equal(service.fetchUrl(url), url.replace(host, proxy), 'API_HOST_PROXY replaced API_HOST through in fetchUrl');
@@ -247,17 +247,17 @@ test('#findRelated', function(assert) {
   const done = assert.async();
 
   // Resource to findRelated on.
-  let resource   = this.container.lookup('model:post').create(postMock.data);
+  let resource   = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let relatedUrl = resource.get('relationships.author.links.related');
   const adapter  = this.subject({type: 'posts', url: '/posts'});
 
   // We expect the authors service to be used.
   this.registry.register('service:authors', Adapter.extend({type: 'authors', url: '/authors'}));
-  let service = this.container.lookup('service:authors');
+  let service = Ember.getOwner(this).lookup('service:authors');
   sandbox.stub(service, 'fetch', function () { return RSVP.Promise.resolve(related); });
 
   // The related resource we expect to find.
-  let related = this.container.lookup('model:author').create(authorMock.data);
+  let related = Ember.getOwner(this).lookup('model:author').create(authorMock.data);
 
   let promise = adapter.findRelated('author', relatedUrl);
 
@@ -276,8 +276,8 @@ test('#findRelated is called with optional type for the resource', function (ass
   assert.expect(4);
   const done = assert.async();
 
-  let supervisor = this.container.lookup('model:supervisor').create(supervisorMock.data);
-  let employee = this.container.lookup('model:employee').create(employeeMock.data);
+  let supervisor = Ember.getOwner(this).lookup('model:supervisor').create(supervisorMock.data);
+  let employee = Ember.getOwner(this).lookup('model:employee').create(employeeMock.data);
 
   let SupervisorAdapter = Adapter.extend({ type: 'supervisors', url: '/supervisors' });
   SupervisorAdapter.reopenClass({isServiceFactory: true});
@@ -287,7 +287,7 @@ test('#findRelated is called with optional type for the resource', function (ass
   this.registry.register('service:employees', EmployeeAdapter.extend({
     cacheLookup: function () { return employee; }
   }));
-  let employeeService = this.container.lookup('service:employees');
+  let employeeService = Ember.getOwner(this).lookup('service:employees');
   let stub = sandbox.stub(employeeService, 'findRelated', function () {
     return RSVP.Promise.resolve(null);
   });
@@ -308,7 +308,7 @@ test('#createResource', function(assert) {
 
   const adapter = this.subject({type: 'posts', url: '/posts'});
   // create new resource (without id, which "server" (response) assigns).
-  let postFactory = this.container.lookup('model:post');
+  let postFactory = Ember.getOwner(this).lookup('model:post');
   let data = JSON.parse(JSON.stringify(postMock.data)); // clones postMock.data
   delete data.id;
   let newResource = postFactory.create(data);
@@ -351,7 +351,7 @@ test('#updateResource updates changed attributes', function(assert) {
   };
   adapter.serializer = mockSerializer({ changed: payload });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
   promise.then(() => {
@@ -373,12 +373,12 @@ test('#updateResource updates (optional) relationships', function(assert) {
   let adapter = this.subject({ type: 'posts', url: '/posts' });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
 
-  let author = this.container.lookup('model:comment').create(postMock.included[0]);
+  let author = Ember.getOwner(this).lookup('model:comment').create(postMock.included[0]);
   author.set('id', '2');
   this.registry.register('service:authors', adapter.constructor.extend({
     cacheLookup: function () { return author; }
   }));
-  let comment = this.container.lookup('model:comment').create(postMock.included[1]);
+  let comment = Ember.getOwner(this).lookup('model:comment').create(postMock.included[1]);
   comment.set('id', '3');
   this.registry.register('service:comments', adapter.constructor.extend({
     cacheLookup: function () { return comment; }
@@ -395,7 +395,7 @@ test('#updateResource updates (optional) relationships', function(assert) {
   };
   adapter.serializer = mockSerializer({ relationships: payload.data.relationships });
 
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   resource.addRelationship('author', '2');
   resource.addRelationship('comments', '3');
 
@@ -421,7 +421,7 @@ test('when serializer returns null (nothing changed) #updateResource return prom
   let adapter = this.subject({type: 'posts', url: '/posts'});
   adapter.serializer = mockSerializer();
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -440,7 +440,7 @@ test('#createRelationship (to-many)', function(assert) {
   let payload = {data: [{type: 'comments', id: '1'}]};
   adapter.serializer = mockSerializer({ relationship: payload });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.createRelationship(resource, 'comments', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -466,7 +466,7 @@ test('#createRelationship (to-one)', function(assert) {
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   mockServices.call(this);
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.createRelationship(resource, 'author', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -491,7 +491,7 @@ test('#createRelationship uses optional resource type', function (assert) {
   let mockRelationSerialized = { data: [{ type: 'employees', id: '1' }] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
+  let resource = Ember.getOwner(this).lookup('model:supervisor').create(supervisorMock.data);
   let promise = adapter.createRelationship(resource, 'directReports', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -516,7 +516,7 @@ test('#deleteRelationship (to-many)', function(assert) {
   let mockRelationSerialized = { data: [{ type: 'comments', id: '1' }] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.deleteRelationship(resource, 'comments', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -541,7 +541,7 @@ test('#deleteRelationship (to-one)', function(assert) {
   let mockRelationSerialized = { data: { type: 'authors', id: '1' } };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.deleteRelationship(resource, 'author', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -566,7 +566,7 @@ test('#deleteRelationship uses optional resource type', function (assert) {
   let mockRelationSerialized = { data: [{ type: 'employees', id: '1' }] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
+  let resource = Ember.getOwner(this).lookup('model:supervisor').create(supervisorMock.data);
   let promise = adapter.deleteRelationship(resource, 'directReports', '1');
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');
@@ -591,7 +591,7 @@ test('#patchRelationship (to-many)', function(assert) {
   let mockRelationSerialized = { data: [{ type: 'comments', id: '1' }] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   resource.addRelationship('comments', '1');
   let promise = adapter.patchRelationship(resource, 'comments');
 
@@ -617,7 +617,7 @@ test('#patchRelationship (to-one)', function(assert) {
   let mockRelationSerialized = { data: { type: 'authors', id: '1' } };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   resource.addRelationship('author', '1');
   let promise = adapter.patchRelationship(resource, 'author');
 
@@ -643,7 +643,7 @@ test('#patchRelationship uses optional resource type', function (assert) {
   let mockRelationSerialized = { data: [{type: 'employees', id: '1'}] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:supervisor').create(supervisorMock.data);
+  let resource = Ember.getOwner(this).lookup('model:supervisor').create(supervisorMock.data);
   resource.addRelationship('directReports', '1');
   let promise = adapter.patchRelationship(resource, 'directReports');
 
@@ -673,7 +673,7 @@ test('createRelationship casts id to string', function (assert) {
   let mockRelationSerialized = { data: [{type: 'comments', id: '1'}] };
   adapter.serializer = mockSerializer({ relationship: mockRelationSerialized });
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let createPromise = adapter.createRelationship(resource, 'comments', 1);
   let deletePromise = adapter.deleteRelationship(resource, 'comments', 1);
 
@@ -723,7 +723,7 @@ test('#deleteResource can be called with a resource having a self link, and call
 
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   sandbox.stub(resource, 'destroy', function () {});
   let promise = adapter.deleteResource(resource);
 
@@ -744,7 +744,7 @@ test('when called with resource argument, #deleteResource calls #cacheRemove', f
 
   const adapter = this.subject({type: 'posts', url: '/posts'});
   sandbox.stub(adapter, 'fetch', function () { return RSVP.Promise.resolve(null); });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   sandbox.stub(adapter, 'cacheRemove', function () {});
   Ember.run(() => {
     adapter.deleteResource(resource);
@@ -859,7 +859,7 @@ test('#cacheUpdate called after #updateResource success', function(assert) {
     }
   };
   adapter.serializer = mockSerializer({ changed: payload });
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let promise = adapter.updateResource(resource);
 
   assert.ok(typeof promise.then === 'function', 'returns a thenable');

--- a/tests/unit/mixins/service-cache-test.js
+++ b/tests/unit/mixins/service-cache-test.js
@@ -11,7 +11,7 @@ moduleFor('mixin:service-cache', 'Unit | Mixin | service-cache', {
     let ServiceCacheObject = Ember.Object.extend(ServiceCacheMixin);
     subject = ServiceCacheObject.create();
     setup.call(this);
-    Post = this.container.lookup('model:post');
+    Post = Ember.getOwner(this).lookup('model:post');
   },
   afterEach() {
     sandbox.restore();

--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -59,7 +59,7 @@ test('in creating instances, ids are cast to string', function (assert) {
 test('in creating instances, optional resource is used to set up relationships', function (assert) {
   assert.expect(2);
 
-  let supervisor = this.container.lookup('model:supervisor').create();
+  let supervisor = Ember.getOwner(this).lookup('model:supervisor').create();
   let meta       = supervisor.constructor.metaForProperty('directReports');
   let relationships = supervisor.get('relationships');
 
@@ -117,7 +117,7 @@ test('attr() uses the attributes hash for computed model attributes', function(a
 });
 
 test('attr() helper creates a computed property using a unique (protected) attributes hash', function(assert) {
-  const Factory = this.container.lookup('model:resource');
+  const Factory = Ember.getOwner(this).lookup('model:resource');
   const PersonFactory = Factory.extend({ name: attr('string'), type: 'person' });
 
   let personA = PersonFactory.create({ attributes: { 'name': 'Ricky' }});
@@ -223,7 +223,7 @@ test('#rollback resets attributes and relationships', function(assert){
 });
 
 test('#didUpdateResource empties the resource _attributes hash when resource id matches json arg id value', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.set('excerpt', 'became a deputy.');
@@ -233,7 +233,7 @@ test('#didUpdateResource empties the resource _attributes hash when resource id 
 });
 
 test('#didUpdateResource does nothing if json argument has an id that does not match the resource id', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.set('excerpt', 'became a deputy.');
@@ -243,7 +243,7 @@ test('#didUpdateResource does nothing if json argument has an id that does not m
 });
 
 test('#relationMetadata', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.' },
     relationships: {
       author: { data: { type: 'authors', id: '1' } },
@@ -264,7 +264,7 @@ test('#relationMetadata', function(assert) {
 
 test('#addRelationship', function(assert) {
   // create resource with relation from json payload.
-  let comment = this.container.lookup('model:comment').create({
+  let comment = Ember.getOwner(this).lookup('model:comment').create({
     id: '4',  attributes: {body: 'Wyatt become a deputy too.' },
     relationships: { commenter: { data: { type: 'commenter', id: '3' } } }
   });
@@ -275,7 +275,7 @@ test('#addRelationship', function(assert) {
 
   // create resource and add relationships through .addRelationship()
   // make sure both relationships exist after all manipulations.
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.addRelationship('author', '2');
@@ -292,7 +292,7 @@ test('#addRelationship', function(assert) {
 });
 
 test('#addRelationship cast id to string', function (assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.addRelationship('author', 1);
@@ -303,7 +303,7 @@ test('#addRelationship cast id to string', function (assert) {
 });
 
 test('#addRelationship tracks relationships changes', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
 
@@ -331,7 +331,7 @@ test('#addRelationship tracks relationships changes', function(assert) {
 });
 
 test('#addRelationships', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'}
   });
   post.addRelationships('comments', ['4', '5']);
@@ -349,20 +349,20 @@ test('#addRelationships', function(assert) {
 test('#removeRelationship', function(assert) {
   // set up models and their relations through create with json payload.
   let post = createPostWithRelationships.call(this);
-  let author = this.container.lookup('model:author').create({
+  let author = Ember.getOwner(this).lookup('model:author').create({
     id: '2', attributes: { name: 'Bill' },
     relationships: {
       posts: { data: [{ type: 'posts', id: '1' }], links: { related: 'url'} }
     }
   });
-  let comment = this.container.lookup('model:comment').create({
+  let comment = Ember.getOwner(this).lookup('model:comment').create({
     id: '3', attributes: { body: 'Wyatt become a deputy too.' },
     relationships: {
       commenter: { data: { type: 'commenters', id: '4' }, links: { related: 'url'} },
       post: { data: { type: 'posts', id: '1' }, links: { related: 'url'} }
     }
   });
-  let commenter = this.container.lookup('model:commenter').create({
+  let commenter = Ember.getOwner(this).lookup('model:commenter').create({
     id: '4', attributes: { name: 'Virgil Erp' },
     relationships: {
       comments: { data: [{ type: 'comments', id: '3' }], links: { related: 'url'} }
@@ -468,7 +468,7 @@ test('#removeRelationship', function(assert) {
 
 test('#removeRelationship casts id to string', function (assert) {
   // set up model and its relations through create with json payload.
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.' },
     relationships: {
       comments: {
@@ -525,13 +525,13 @@ test('#changedRelationships', function(assert) {
 });
 
 test('#didResolveProxyRelation', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: { data: { type: 'authors', id: '2'}, links: { related: 'url-here'} }
     }
   });
-  let author = this.container.lookup('model:author').create({
+  let author = Ember.getOwner(this).lookup('model:author').create({
     id: '2', attributes: { name: 'Bill' },
     relationships: {
       posts: { data: [{ type: 'posts', id: '1' }], links: { related: 'url-here'} }
@@ -553,7 +553,7 @@ test('#didResolveProxyRelation', function(assert) {
 
 test('#isNew resource uses relations without proxied content', function(assert) {
   let serviceOp = this.sandbox.spy();
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     isNew: true,
     // mock service
@@ -602,7 +602,7 @@ test('#updateRelationship, from resource-operations mixin', function(assert) {
   let serviceOp = this.sandbox.spy(function() {
     return RSVP.Promise.resolve(null);
   });
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.' },
     relationships: {
       author: { data: { type: 'authors', id: '2' }, links: { related: 'url-here'} },
@@ -642,14 +642,14 @@ test('#updateRelationship, from resource-operations mixin', function(assert) {
 });
 
 function createPost() {
-  return this.container.lookup('model:post').create({
+  return Ember.getOwner(this).lookup('model:post').create({
     id: '1',
     attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.' }
   });
 }
 
 function createPostWithRelationships() {
-  return this.container.lookup('model:post').create({
+  return Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {
       title: 'Wyatt Earp', excerpt: 'Was a gambler.'
     },

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
 import { setup, teardown, mockServices } from 'dummy/tests/helpers/resources';
-
+import Ember from 'ember';
 import authorMock from 'fixtures/api/authors/1';
 import postMock from 'fixtures/api/posts/1';
 
@@ -36,7 +36,7 @@ test('#serialize calls serializeResource', function(assert) {
 
 test('#serializeResource with only attributes data', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookup('model:author').create({
+  let resource = Ember.getOwner(this).lookup('model:author').create({
     attributes: authorMock.data.attributes
   });
   let data = serializer.serializeResource(resource);
@@ -54,7 +54,7 @@ test('#serializeResource with only attributes data', function(assert) {
 test('#serializeResource with attributes and relationship', function(assert) {
   const serializer = this.subject();
   mockServices.call(this);
-  let resource = this.container.lookup('model:post').create({
+  let resource = Ember.getOwner(this).lookup('model:post').create({
     attributes: postMock.data.attributes
   });
   resource.addRelationship('author', '1');
@@ -75,7 +75,7 @@ test('#serializeResource with attributes and relationship', function(assert) {
 
 test('#serializeChanged', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let changedTitle = postMock.data.attributes.title + ' changed';
   resource.set('title', changedTitle);
   let serialized = serializer.serializeChanged(resource);
@@ -89,7 +89,7 @@ test('#serializeChanged', function(assert) {
 
 test('when #serializedChanged has nothing to return', function(assert) {
   const serializer = this.subject();
-  let resource = this.container.lookup('model:post').create(postMock.data);
+  let resource = Ember.getOwner(this).lookup('model:post').create(postMock.data);
   let serialized = serializer.serializeChanged(resource);
   assert.equal(serialized, null, 'null is returned when there are no changed attributes');
 });
@@ -116,7 +116,7 @@ test('#serializeRelationships', function(assert) {
 });
 
 function createPost() {
-  return this.container.lookup('model:post').create({
+  return Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: {
       title: 'Wyatt Earp', excerpt: 'Was a gambler.'
     },

--- a/tests/unit/utils/has-many-test.js
+++ b/tests/unit/utils/has-many-test.js
@@ -32,7 +32,7 @@ moduleFor('model:resource', 'Unit | Utility | hasMany', {
 });
 
 test('hasMany() helper sets up a promise proxy to a related resource', function(assert) {
-  let author = this.container.lookup('model:author').create({
+  let author = Ember.getOwner(this).lookup('model:author').create({
     id: '1', attributes: { name: 'pixelhandler' },
     relationships: {
       posts: {
@@ -43,7 +43,7 @@ test('hasMany() helper sets up a promise proxy to a related resource', function(
       }
     }
   });
-  this.container.lookup('model:post').create({
+  Ember.getOwner(this).lookup('model:post').create({
     id: '2', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {

--- a/tests/unit/utils/has-one-test.js
+++ b/tests/unit/utils/has-one-test.js
@@ -33,7 +33,7 @@ moduleFor('model:resource', 'Unit | Utility | hasOne', {
 });
 
 test('hasOne() helper sets up a promise proxy to a related resource', function(assert) {
-  let post = this.container.lookup('model:post').create({
+  let post = Ember.getOwner(this).lookup('model:post').create({
     id: '1', attributes: { title: 'Wyatt Earp', excerpt: 'Was a gambler.'},
     relationships: {
       author: {


### PR DESCRIPTION
Remove usage of this.container.
This will make the addon only work with Ember.js > 2.3 and will most likely want a major version bump after this is merged in.