### PR TITLE
Failing tests for previousAttributes/rollbackAttributes

### DIFF
--- a/tests/unit/models/resource-test.js
+++ b/tests/unit/models/resource-test.js
@@ -153,27 +153,55 @@ test('#changedAttributes', function(assert) {
 
 test('#previousAttributes', function(assert) {
   let post = createPost.call(this);
+  let previous;
+
   assert.equal(post.get('excerpt'), 'Was a gambler.', 'excerpt is set to "Was a gambler."');
   post.set('excerpt', 'Became a deputy.');
   assert.equal(post.get('excerpt'), 'Became a deputy.', 'excerpt is set to "Became a deputy."');
 
-  let previous = post.get('previousAttributes');
+  previous = post.get('previousAttributes');
+  assert.equal(Object.keys(previous).join(''), 'excerpt', 'previous attributes include only excerpt');
+  assert.equal(previous.excerpt, 'Was a gambler.', 'previous excerpt value is "Was a gambler."');
+
+  // Several changes
+  post.set('excerpt', 'Became the sheriff.');
+  post.set('excerpt', 'Became the chief.');
+  post.set('excerpt', 'Became the mayor.');
+
+  previous = post.get('previousAttributes');
   assert.equal(Object.keys(previous).join(''), 'excerpt', 'previous attributes include only excerpt');
   assert.equal(previous.excerpt, 'Was a gambler.', 'previous excerpt value is "Was a gambler."');
 });
 
 test('#rollbackAttributes resets attributes based on #previousAttributes', function(assert) {
   let post = createPost.call(this);
+  let previous;
+
   assert.equal(post.get('excerpt'), 'Was a gambler.', 'excerpt is set to "Was a gambler."');
   post.set('excerpt', 'Became a deputy.');
   assert.equal(post.get('excerpt'), 'Became a deputy.', 'excerpt is set to "Became a deputy."');
-  let previous = post.get('previousAttributes');
+
+  previous = post.get('previousAttributes');
+
   assert.equal(previous.excerpt, 'Was a gambler.', 'previous excerpt value is "Was a gambler."');
   assert.equal(Object.keys(previous).length, 1, 'previous attribues have one change tracked');
 
   post.rollbackAttributes();
 
   previous = post.get('previousAttributes');
+  assert.equal(post.get('excerpt'), 'Was a gambler.', 'excerpt is set to "Was a gambler."');
+  assert.equal(Object.keys(previous).length, 0, 'previous attribues are empty');
+
+  // Several changes
+  post.set('excerpt', 'Became the sheriff.');
+  post.set('excerpt', 'Became the chief.');
+  post.set('excerpt', 'Became the mayor.');
+
+  post.rollbackAttributes();
+
+  previous = post.get('previousAttributes');
+
+  // Should rollback to initially fetched value
   assert.equal(post.get('excerpt'), 'Was a gambler.', 'excerpt is set to "Was a gambler."');
   assert.equal(Object.keys(previous).length, 0, 'previous attribues are empty');
 });


### PR DESCRIPTION
Current behavior is to stash an attribute’s value on EVERY call to .set(). The intent seems to be to rollback to the value fetched from the persistence layer.

As illustrated by the tests:

```
post.get(‘excerpt’); // ‘Was a gambler.’

post.set('excerpt', 'Became the sheriff.');
post.set('excerpt', 'Became the chief.');
post.set('excerpt', 'Became the mayor.');

post.get('previousAttributes.excerpt’); // 'Became the chief.'
```

The previous value is simply the previous change ('Became the chief’) instead of the “original” value (“Was a gambler”).

The new tests FAIL to show that “previousAttributes” and “rollbackAttributes” to not behave as expected.