### PR TITLE
Actually update resource.

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -261,7 +261,7 @@ export default Ember.Object.extend(Evented, {
       // just call `didUpdateResource` on the actual resource we were given.
       // `didUpdateResource` itself is updated to check if relationship data needs
       // to be reset.
-      resource.didUpdateResource(json.data);
+      resource.didUpdateResource(this.serializer.serializeResource(resource));
     });
   },
 

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -139,7 +139,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
   */
   _updateRelationshipsData(relation, ids) {
     if (!Array.isArray(ids)) {
-      this._updateToOneRelationshipData(relation, ids); 
+      this._updateToOneRelationshipData(relation, ids);
     } else {
       let existing = this._existingRelationshipData(relation);
       if (!existing.length) {
@@ -178,7 +178,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
   */
   _replaceRelationshipsData(relation, ids) {
     if (!Array.isArray(ids)) {
-      this._updateToOneRelationshipData(relation, ids); 
+      this._updateToOneRelationshipData(relation, ids);
     } else {
       let existing = this._existingRelationshipData(relation);
       if (!existing.length) {
@@ -526,7 +526,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
 
   /**
     Sets all payload properties on the resource and resets private _attributes
-    used for changed/previous tracking
+    and _relationships used for changed/previous tracking
 
     @method didUpdateResource
     @param {Object} json the updated data for the resource
@@ -535,6 +535,9 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     if (this.get('id') !== json.id) { return; }
     this.setProperties(json);
     this._resetAttributes();
+    if (json.relationships) {
+      this._resetRelationships();
+    }
   },
 
   /**


### PR DESCRIPTION
This extends what I feel was a hack (the `cleanup` method) to fix resources not updating (stuck in dirty state).