### PR TITLE
Ember.copy values to 'changed' and 'previous'

### DIFF
--- a/addon/utils/attr.js
+++ b/addon/utils/attr.js
@@ -72,9 +72,9 @@ export default function attr(type = 'any', mutable = true) {
       if (!this.get('isNew')) {
         this._attributes[key] = this._attributes[key] || {};
         if (this._attributes[key].previous === undefined) {
-          this._attributes[key].previous = lastValue;
+          this._attributes[key].previous = Ember.copy(lastValue, true);
         }
-        this._attributes[key].changed = value;
+        this._attributes[key].changed = Ember.copy(value, true);
         let service = this.get('service');
         if (service) {
           service.trigger('attributeChanged', this);


### PR DESCRIPTION
Without this, changes in attributes of type `object` and `array` are never tracked, since they are simply referenced as/to `changed` and `previous`, so they are always the same.

Copying the objects will actually detect the changes in these attributes. 

Might not be the best idea performance-wise, but there are probably very few complicated/large arrays or objects that are simply attributes on a model/resource, and relationship changes are tracked seperately.