### PR TITLE
Initialize empty toOne relationships actually empty

### DIFF
--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -63,7 +63,7 @@ const RelatedProxyUtil = Ember.Object.extend({
       newContent = Ember.A([]);
     } else if (kind === 'toOne') {
       proxyFactory = Ember.ObjectProxy;
-      newContent = Ember.Object.create();
+      newContent = null;
     }
     if (resource.get('isNew')) {
       return proxyFactory.create({ content: newContent });
@@ -92,7 +92,7 @@ const RelatedProxyUtil = Ember.Object.extend({
       'promise': promise, 'type': relation, 'kind': kind
     });
     return proxyProto.create({
-      content: (kind === 'toOne') ? Ember.Object.create() : Ember.A([])
+      content: (kind === 'toOne') ? null : Ember.A([])
     });
   },
 


### PR DESCRIPTION
`ObjectProxy`s for `toOne` relationships were initialised with a fresh `Ember.Object.create()` as their content. Because of this, you can not do this:

`if (resource.get('some-to-one-relationship')) { ... }` or `{{#if resource.some-to-one-relationship}} ... {{/if}}` 

`resource.get('some-to-one-relationship.content')` would not work either. You'd have to go look for attributes:`resource.get('some-to-one-relationship.id')`.
But that doesn't work either, since there isn't really an attribute that should always be set... Maybe `type`, but that's just a hack.

By initialising with something falsy like `null`, we're all good.