### PR TITLE
Promise aware to one object proxy

### DIFF
--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -63,7 +63,7 @@ const RelatedProxyUtil = Ember.Object.extend({
       newContent = Ember.A([]);
     } else if (kind === 'toOne') {
       proxyFactory = Ember.ObjectProxy;
-      newContent = Ember.Object.create();
+      newContent = null;
     }
     if (resource.get('isNew')) {
       return proxyFactory.create({ content: newContent });
@@ -92,7 +92,7 @@ const RelatedProxyUtil = Ember.Object.extend({
       'promise': promise, 'type': relation, 'kind': kind
     });
     return proxyProto.create({
-      content: (kind === 'toOne') ? Ember.Object.create() : Ember.A([])
+      content: (kind === 'toOne') ? null : Ember.A([])
     });
   },
 

--- a/addon/utils/related-proxy.js
+++ b/addon/utils/related-proxy.js
@@ -62,7 +62,9 @@ const RelatedProxyUtil = Ember.Object.extend({
       proxyFactory = Ember.ArrayProxy;
       newContent = Ember.A([]);
     } else if (kind === 'toOne') {
-      proxyFactory = Ember.ObjectProxy;
+      proxyFactory = Ember.ObjectProxy.extend(Ember.PromiseProxyMixin, {
+        promise: new Ember.RSVP.Promise(resolve => { resolve(null); })
+      });
       newContent = null;
     }
     if (resource.get('isNew')) {


### PR DESCRIPTION
This is somewhat related to https://github.com/pixelhandler/ember-jsonapi-resources/pull/141.

related proxy's are promise/able, except when they're not. Empty relationships do not support promises, so you can't always go `model.get('some-relationship').then(relationship => { if (relationship) { // we have a relationship })` because there is no `then` for empty relationships.

Again, no tests for this (except that the current tests don't break). I will eventually add some, but I need to get my actual Ember app going, so I'm currently just collecting bugs and fixes. (if all these PRs and communication is not useful I can stack all these changes/bugs/issues/fixes on my own fork and discuss them later).