### PR TITLE
[WIP] Relationship changes

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -232,22 +232,22 @@ export default Ember.Object.extend(Evented, {
     let url = resource.get('links.self') || this.get('url') + '/' + resource.get('id');
     let json = this.serializer.serializeChanged(resource);
     let relationships = this.serializer.serializeRelationships(resource, includeRelationships);
-    if ((includeRelationships &&
-          ((!json && !relationships) || (!json && relationships.length === 0))) ||
-        (!includeRelationships && !json)) {
+    console.log(json, relationships);
+    if (Ember.isEmpty(json) && Ember.isEmpty(relationships)) {
       return RSVP.Promise.resolve(null);
     }
+
     json = json || { data: { id: resource.get('id'), type: resource.get('type') } };
-    let cleanup = Ember.K;
+
     if (relationships) {
       json.data.relationships = relationships;
-      cleanup = resource._resetRelationships.bind(resource);
     }
+
     return this.fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(json),
       update: true
-    }).then(cleanup);
+    }).then(resource.didUpdateResource.bind(resource));
   },
 
   /**

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -401,7 +401,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
   */
   removeRelationship(related, id) {
     // Debug: I want to know when relationship removals are tracked.
-    Ember.Logger.debug('_relationRemoved', this.toString(), related, id);
+    Logger.debug('removeRelationship', this.toString(), related, id);
     console.trace();
 
     if (id !== undefined) { id = id.toString(); } // ensure String ids.
@@ -438,7 +438,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
   */
   _relationRemoved(relation, id) {
     // Debug: I want to know when relationship removals are tracked.
-    Ember.Logger.debug('_relationRemoved', this.toString(), relation, id);
+    Logger.debug('_relationRemoved', this.toString(), relation, id);
 
     let ref = this._relationships[relation] = this._relationships[relation] || {};
     let meta = this.relationMetadata(relation);
@@ -639,7 +639,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
   */
   didUpdateResource(json) {
     // Debug: I want to know when this callback is triggered.
-    Ember.Logger.debug('_relationRemoved', this.toString(), json);
+    Logger.debug('didUpdateResource', this.toString(), json);
 
     // Received payload does not have to represent the full resource as we know it
     // client-side. Specifically, relationship data can be safely omitted in payload,

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -345,9 +345,11 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     let meta = this.relationMetadata(relation);
     let ref  = this._relationships[relation];
 
-    // TODO: Remove this? Why reset tracking?
+    // FIXME: Why setup tracking here each time? I've moved the call
+    // to this._resetRelationships.
     // setupRelationshipTracking.call(this, relation, meta.kind);
-    // TODO: why look up data when we get passed `previous`?
+
+    // FIXME: why look up data when we get passed `previous`?
     // let relationshipData = this.get(`relationships.${relation}.data`);
     if (meta && meta.kind === 'toOne') {
       ref.changed = identifier;
@@ -581,11 +583,13 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     @method _resetRelationships
   */
   _resetRelationships() {
-    for (let attr in this._relationships) {
-      if (this._relationships.hasOwnProperty(attr)) {
-        delete this._relationships[attr];
+    for (let relation in this._relationships) {
+      if (this._relationships.hasOwnProperty(relation)) {
+        let meta = this.relationMetadata(relation);
+        setupRelationshipTracking.call(this, relation, meta.kind);
       }
     }
+
     this.set('_changedRelationships', Ember.A([]));
   },
 
@@ -619,6 +623,7 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
     @param {Object} json the updated data for the resource
   */
   didUpdateResource(json) {
+    console.log('resource didUpdate', this.toString());
     // Received payload does not have to represent the full resource as we know it
     // client-side. Specifically, relationship data can be safely omitted in payload,
     // but that does not invalidate the relationship data we have stored client-side.

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -325,14 +325,17 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
       }
     }
 
-    if (!this.get('_changedRelationships')) {
-      this.set('_changedRelationships', Ember.A([]));
-    }
+    // Track relationship changes
+    if (!this.get('isNew')) {
+      if (!this.get('_changedRelationships')) {
+        this.set('_changedRelationships', Ember.A([]));
+      }
 
-    if (!Ember.isEmpty(ref.added) ||
-        !Ember.isEmpty(ref.removals) ||
-        !Ember.isEmpty(ref.changed)) {
-      this.get('_changedRelationships').pushObject(relation);
+      if (!Ember.isEmpty(ref.added) ||
+          !Ember.isEmpty(ref.removals) ||
+          !Ember.isEmpty(ref.changed)) {
+        this.get('_changedRelationships').pushObject(relation);
+      }
     }
   },
 
@@ -399,13 +402,16 @@ const Resource = Ember.Object.extend(ResourceOperationsMixin, {
       }
     }
 
-    if (!this.get('_changedRelationships')) {
-      this.set('_changedRelationships', Ember.A([]));
-    }
-    if (!Ember.isEmpty(ref.added) ||
-        !Ember.isEmpty(ref.removals) ||
-        !Ember.isEmpty(ref.previous)) {
-      this.get('_changedRelationships').removeObject(relation);
+    // Track relationship changes.
+    if (!this.get('isNew')) {
+      if (!this.get('_changedRelationships')) {
+        this.set('_changedRelationships', Ember.A([]));
+      }
+      if (!Ember.isEmpty(ref.added) ||
+          !Ember.isEmpty(ref.removals) ||
+          !Ember.isEmpty(ref.previous)) {
+        this.get('_changedRelationships').removeObject(relation);
+      }
     }
   },
 

--- a/addon/utils/attr.js
+++ b/addon/utils/attr.js
@@ -63,18 +63,49 @@ export default function attr(type = 'any', mutable = true) {
 
     set: function (key, value) {
       const lastValue = this.get('attributes.' + key);
+      // Don't allow set on immutable values.
       if (!_mutable) {
         return immutableValue(key, value, lastValue);
       }
+      // Don't do anything if same value is set.
       if (value === lastValue) { return value; }
+
+      // Check value type.
       assertType.call(this, key, value);
+
+      // Set value.
       this.set('attributes.' + key, value);
+
+      // Track changes.
+      // Only on non-isNew resources, which are 'dirty' be default
       if (!this.get('isNew')) {
+        // Initialize tracking object and array for this attribute.
         this._attributes[key] = this._attributes[key] || {};
-        if (this._attributes[key].previous === undefined) {
-          this._attributes[key].previous = lastValue;
+        if (!this.get('_changedAttributes')) {
+          this.set('_changedAttributes', Ember.A([]));
         }
-        this._attributes[key].changed = value;
+
+        // Track change(d key) and store previous/changed value.
+        // We (Ember.)Copy values to `previous` and `changed` to prevent both
+        // being a reference to the same object (and thus never showing up on
+        // computed property 'changedAttributes')
+        if (this._attributes[key].previous === undefined) {
+          // Value changed for the first time.
+          this._attributes[key].previous = Ember.copy(lastValue, true);
+          this.get('_changedAttributes').pushObject(key);
+        } else {
+          // Value changed again.
+          if (this._attributes[key].previous === value) {
+            // Value reverted to previous. No longer dirty. Remove from tracking.
+            this.get('_changedAttributes').removeObject(key);
+          } else if (this.get('_changedAttributes').indexOf(key) === -1){
+            // Value changed again, wasn't tracked anymore. Track it.
+            this.get('_changedAttributes').pushObject(key);
+          }
+        }
+
+        this._attributes[key].changed = Ember.copy(value, true);
+
         let service = this.get('service');
         if (service) {
           service.trigger('attributeChanged', this);


### PR DESCRIPTION
These are my WIP changes regarding relationship tracking.

This is:
- [live attr and rel tracking](https://github.com/pixelhandler/ember-jsonapi-resources/pull/140)
- [handling 204 responses, dealing with ember-fetchjax change](https://github.com/pixelhandler/ember-fetchjax/pull/1)
- seperate `addRelationship` and `_addRelationship`, the latter is private and does not track (relationships pushed by server are not dirty/changes)
  - [WIP] do the same for `removeRelationship`
- move 'setupRelationshipTracking` to `_resetRelationships`.
- minor bugfixes (removal of `toOne` in `changedRelationships`)
- minor cleanup (long `includeRelationships` if statement in `updateResource`)

